### PR TITLE
Extend error and notice notification with threadsafe variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,10 +268,10 @@ else()
    find_program(SH sh)
    if(SH)
       execute_process(COMMAND ${SH} -c 
-      "cd ${CMAKE_SOURCE_DIR} && ${CMAKE_SOURCE_DIR}/tools/svn_repo_revision.sh")
+      "cd ${CMAKE_CURRENT_SOURCE_DIR} && ${CMAKE_CURRENT_SOURCE_DIR}/tools/svn_repo_revision.sh")
 
-      file(RENAME "${CMAKE_SOURCE_DIR}/geos_svn_revision.h"
-      "${CMAKE_BINARY_DIR}/geos_svn_revision.h")
+      file(RENAME "${CMAKE_CURRENT_SOURCE_DIR}/geos_svn_revision.h"
+      "${CMAKE_CURRENT_BINARY_DIR}/geos_svn_revision.h")
    else()
       message("*** sh-compatible command not found, cannot create geos_svn_revision.h")
       message("*** Check SVN revision and create revision header manually:")

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -92,7 +92,10 @@ extern "C" {
  *
  ************************************************************************/
 
+typedef struct GEOSContextHandle_HS *GEOSContextHandle_t;
+
 typedef void (*GEOSMessageHandler)(const char *fmt, ...);
+typedef void (*GEOSMessageHandler_r)(GEOSContextHandle_t handle, void *data, const char *fmt, ...);
 
 /* When we're included by geos_c.cpp, those are #defined to the original
  * JTS definitions via preprocessor. We don't touch them to allow the
@@ -136,8 +139,6 @@ enum GEOSByteOrders {
     GEOS_WKB_NDR = 1 /* Little Endian */
 };
 
-typedef struct GEOSContextHandle_HS *GEOSContextHandle_t;
-
 typedef void (*GEOSQueryCallback)(void *item, void *userdata);
 
 /************************************************************************
@@ -169,12 +170,28 @@ extern void GEOS_DLL GEOS_interruptCancel();
 extern GEOSContextHandle_t GEOS_DLL initGEOS_r(
                                     GEOSMessageHandler notice_function,
                                     GEOSMessageHandler error_function);
+extern GEOSContextHandle_t GEOS_DLL initGEOS_r_v2(
+                                    GEOSMessageHandler_r notice_function,
+                                    void *notice_user_data,
+                                    void(*free_notice_user_data)(void*),
+                                    GEOSMessageHandler_r error_function,
+                                    void *error_user_data,
+                                    void(*free_error_user_data)(void*));
 extern void GEOS_DLL finishGEOS_r(GEOSContextHandle_t handle);
 
 extern GEOSMessageHandler GEOS_DLL GEOSContext_setNoticeHandler_r(GEOSContextHandle_t extHandle,
                                                                   GEOSMessageHandler nf);
 extern GEOSMessageHandler GEOS_DLL GEOSContext_setErrorHandler_r(GEOSContextHandle_t extHandle,
                                                                  GEOSMessageHandler ef);
+
+extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setNoticeHandler_r_v2(GEOSContextHandle_t extHandle,
+                                                                       GEOSMessageHandler_r nf,
+                                                                       void *userData,
+                                                                       void(*freeUserData)(void*));
+extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setErrorHandler_r_v2(GEOSContextHandle_t extHandle,
+                                                                      GEOSMessageHandler_r ef,
+                                                                      void *userData,
+                                                                      void(*freeUserData)(void*));
 
 extern const char GEOS_DLL *GEOSversion();
 

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -99,14 +99,14 @@ typedef void (*GEOSMessageHandler)(const char *fmt, ...);
 /*
  * A GEOS message handler function.
  *
- * @param handle the GEOS context that generated the message
- * @param data the user data pointer that was passed to GEOS when registering this message handler.
  * @param message the message contents
+ * @param userdata the user data pointer that was passed to GEOS when registering this message handler.
+ * 
  *
  * @see GEOSContext_setErrorMessageHandler
  * @see GEOSContext_setNoticeMessageHandler
  */
-typedef void (*GEOSMessageHandler_r)(GEOSContextHandle_t handle, void *data, const char *message);
+typedef void (*GEOSMessageHandler_r)(const char *message, void *userdata);
 
 /* When we're included by geos_c.cpp, those are #defined to the original
  * JTS definitions via preprocessor. We don't touch them to allow the

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -178,14 +178,15 @@ extern void GEOS_DLL GEOS_interruptRequest();
 extern void GEOS_DLL GEOS_interruptCancel();
 
 /*
- * @deprecated initialize using GEOS_init_r() and set the message handlers using GEOSContext_setNoticeHandler_r and/or
- *             GEOSContext_setErrorHandler_r subsequently.
+ * @deprecated in 3.5.0
+ *     initialize using GEOS_init_r() and set the message handlers using
+ *     GEOSContext_setNoticeHandler_r and/or GEOSContext_setErrorHandler_r
  */
 extern GEOSContextHandle_t GEOS_DLL initGEOS_r(
                                     GEOSMessageHandler notice_function,
                                     GEOSMessageHandler error_function);
 /*
- * @deprecated replaced by GEOS_finish_r.
+ * @deprecated in 3.5.0 replaced by GEOS_finish_r.
  */
 extern void GEOS_DLL finishGEOS_r(GEOSContextHandle_t handle);
 

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -204,15 +204,12 @@ extern GEOSMessageHandler GEOS_DLL GEOSContext_setErrorHandler_r(GEOSContextHand
  * @param extHandle the GEOS context
  * @param nf the message handler
  * @param userData optional user data pointer that will be passed to the message handler
- * @param freeUserData If not NULL this function will be called with userData as parameter on a subsequent call
- *                     to this function or when the given GEOS context is destroyed
  *
  * @return the previously configured message handler or NULL if no message handler was configured
  */
 extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setNoticeMessageHandler_r(GEOSContextHandle_t extHandle,
                                                                            GEOSMessageHandler_r nf,
-                                                                           void *userData,
-                                                                           void(*freeUserData)(void*));
+                                                                           void *userData);
 
 /*
  * Sets an error message handler on the given GEOS context.
@@ -220,15 +217,12 @@ extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setNoticeMessageHandler_r(GEOSC
  * @param extHandle the GEOS context
  * @param ef the message handler
  * @param userData optional user data pointer that will be passed to the message handler
- * @param freeUserData If not NULL this function will be called with userData as parameter on a subsequent call
- *                     to this function or when the given GEOS context is destroyed
  *
  * @return the previously configured message handler or NULL if no message handler was configured
  */
 extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setErrorMessageHandler_r(GEOSContextHandle_t extHandle,
                                                                           GEOSMessageHandler_r ef,
-                                                                          void *userData,
-                                                                          void(*freeUserData)(void*));
+                                                                          void *userData);
 
 extern const char GEOS_DLL *GEOSversion();
 

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -95,7 +95,18 @@ extern "C" {
 typedef struct GEOSContextHandle_HS *GEOSContextHandle_t;
 
 typedef void (*GEOSMessageHandler)(const char *fmt, ...);
-typedef void (*GEOSMessageHandler_r)(GEOSContextHandle_t handle, void *data, const char *fmt, ...);
+
+/*
+ * A GEOS message handler function.
+ *
+ * @param handle the GEOS context that generated the message
+ * @param data the user data pointer that was passed to GEOS when registering this message handler.
+ * @param message the message contents
+ *
+ * @see GEOSContext_setErrorMessageHandler
+ * @see GEOSContext_setNoticeMessageHandler
+ */
+typedef void (*GEOSMessageHandler_r)(GEOSContextHandle_t handle, void *data, const char *message);
 
 /* When we're included by geos_c.cpp, those are #defined to the original
  * JTS definitions via preprocessor. We don't touch them to allow the
@@ -166,32 +177,58 @@ extern void GEOS_DLL GEOS_interruptRequest();
 /* Cancel a pending interruption request */
 extern void GEOS_DLL GEOS_interruptCancel();
 
-
+/*
+ * @deprecated initialize using GEOS_init_r() and set the message handlers using GEOSContext_setNoticeHandler_r and/or
+ *             GEOSContext_setErrorHandler_r subsequently.
+ */
 extern GEOSContextHandle_t GEOS_DLL initGEOS_r(
                                     GEOSMessageHandler notice_function,
                                     GEOSMessageHandler error_function);
-extern GEOSContextHandle_t GEOS_DLL initGEOS_r_v2(
-                                    GEOSMessageHandler_r notice_function,
-                                    void *notice_user_data,
-                                    void(*free_notice_user_data)(void*),
-                                    GEOSMessageHandler_r error_function,
-                                    void *error_user_data,
-                                    void(*free_error_user_data)(void*));
+/*
+ * @deprecated replaced by GEOS_finish_r.
+ */
 extern void GEOS_DLL finishGEOS_r(GEOSContextHandle_t handle);
+
+extern GEOSContextHandle_t GEOS_DLL GEOS_init_r();
+extern void GEOS_DLL GEOS_finish_r(GEOSContextHandle_t handle);
+
 
 extern GEOSMessageHandler GEOS_DLL GEOSContext_setNoticeHandler_r(GEOSContextHandle_t extHandle,
                                                                   GEOSMessageHandler nf);
 extern GEOSMessageHandler GEOS_DLL GEOSContext_setErrorHandler_r(GEOSContextHandle_t extHandle,
                                                                  GEOSMessageHandler ef);
 
-extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setNoticeHandler_r_v2(GEOSContextHandle_t extHandle,
-                                                                       GEOSMessageHandler_r nf,
-                                                                       void *userData,
-                                                                       void(*freeUserData)(void*));
-extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setErrorHandler_r_v2(GEOSContextHandle_t extHandle,
-                                                                      GEOSMessageHandler_r ef,
-                                                                      void *userData,
-                                                                      void(*freeUserData)(void*));
+/*
+ * Sets a notice message handler on the given GEOS context.
+ *
+ * @param extHandle the GEOS context
+ * @param nf the message handler
+ * @param userData optional user data pointer that will be passed to the message handler
+ * @param freeUserData If not NULL this function will be called with userData as parameter on a subsequent call
+ *                     to this function or when the given GEOS context is destroyed
+ *
+ * @return the previously configured message handler or NULL if no message handler was configured
+ */
+extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setNoticeMessageHandler_r(GEOSContextHandle_t extHandle,
+                                                                           GEOSMessageHandler_r nf,
+                                                                           void *userData,
+                                                                           void(*freeUserData)(void*));
+
+/*
+ * Sets an error message handler on the given GEOS context.
+ *
+ * @param extHandle the GEOS context
+ * @param ef the message handler
+ * @param userData optional user data pointer that will be passed to the message handler
+ * @param freeUserData If not NULL this function will be called with userData as parameter on a subsequent call
+ *                     to this function or when the given GEOS context is destroyed
+ *
+ * @return the previously configured message handler or NULL if no message handler was configured
+ */
+extern GEOSMessageHandler_r GEOS_DLL GEOSContext_setErrorMessageHandler_r(GEOSContextHandle_t extHandle,
+                                                                          GEOSMessageHandler_r ef,
+                                                                          void *userData,
+                                                                          void(*freeUserData)(void*));
 
 extern const char GEOS_DLL *GEOSversion();
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -150,14 +150,14 @@ typedef struct GEOSContextHandle_HS
     int WKBByteOrder;
     int initialized;
 
-    GEOSContextHandle_HS(GEOSMessageHandler_r nf, void *nd, void(*free_nd)(void*), GEOSMessageHandler_r ef, void *ed, void(*free_ed)(void*))
+    GEOSContextHandle_HS()
     {
       memset(msgBuffer, 0, sizeof(msgBuffer));
       geomFactory = GeometryFactory::getDefaultInstance();
       WKBOutputDims = 2;
       WKBByteOrder = getMachineByteOrder();
-      setNoticeHandler(nf, nd, free_nd);
-      setErrorHandler(ef, ed, free_ed);
+      setNoticeHandler(NULL);
+      setErrorHandler(NULL);
       initialized = 1;
     }
 
@@ -242,7 +242,7 @@ typedef struct GEOSContextHandle_HS
         if (noticeMessageOld) {
           noticeMessageOld("%s", msgBuffer);
         } else {
-          noticeMessageNew(this, noticeData, "%s", msgBuffer);
+          noticeMessageNew(this, noticeData, msgBuffer);
         }
       }
     }
@@ -263,7 +263,7 @@ typedef struct GEOSContextHandle_HS
         if (errorMessageOld) {
           errorMessageOld("%s", msgBuffer);
         } else {
-          errorMessageNew(this, errorData, "%s", msgBuffer);
+          errorMessageNew(this, errorData, msgBuffer);
         }
       }
     }
@@ -322,7 +322,7 @@ extern "C" {
 GEOSContextHandle_t
 initGEOS_r(GEOSMessageHandler nf, GEOSMessageHandler ef)
 {
-  GEOSContextHandle_t handle = initGEOS_r_v2(NULL, NULL, NULL, NULL, NULL, NULL);
+  GEOSContextHandle_t handle = GEOS_init_r();
 
   if (0 != handle) {
       GEOSContext_setNoticeHandler_r(handle, nf);
@@ -333,9 +333,9 @@ initGEOS_r(GEOSMessageHandler nf, GEOSMessageHandler ef)
 }
 
 GEOSContextHandle_t
-initGEOS_r_v2(GEOSMessageHandler_r nf, void *nd, void(*free_nd)(void*), GEOSMessageHandler_r ef, void *ed, void(*free_ed)(void*))
+GEOS_init_r()
 {
-    GEOSContextHandleInternal_t *handle = new GEOSContextHandleInternal_t(nf, nd, free_nd, ef, ed, free_ed);
+    GEOSContextHandleInternal_t *handle = new GEOSContextHandleInternal_t();
 
     geos::util::Interrupt::cancel();
 
@@ -369,7 +369,7 @@ GEOSContext_setErrorHandler_r(GEOSContextHandle_t extHandle, GEOSMessageHandler 
 }
 
 GEOSMessageHandler_r
-GEOSContext_setNoticeHandler_r_v2(GEOSContextHandle_t extHandle, GEOSMessageHandler_r nf, void *userData, void(*freeUserData)(void*)) {
+GEOSContext_setNoticeMessageHandler_r(GEOSContextHandle_t extHandle, GEOSMessageHandler_r nf, void *userData, void(*freeUserData)(void*)) {
     GEOSContextHandleInternal_t *handle = 0;
     handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
     if ( 0 == handle->initialized )
@@ -381,7 +381,7 @@ GEOSContext_setNoticeHandler_r_v2(GEOSContextHandle_t extHandle, GEOSMessageHand
 }
 
 GEOSMessageHandler_r
-GEOSContext_setErrorHandler_r_v2(GEOSContextHandle_t extHandle, GEOSMessageHandler_r ef, void *userData, void(*freeUserData)(void*))
+GEOSContext_setErrorMessageHandler_r(GEOSContextHandle_t extHandle, GEOSMessageHandler_r ef, void *userData, void(*freeUserData)(void*))
 {
     GEOSContextHandleInternal_t *handle = 0;
     handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
@@ -399,6 +399,12 @@ finishGEOS_r(GEOSContextHandle_t extHandle)
     // Fix up freeing handle w.r.t. malloc above
     delete extHandle;
     extHandle = NULL;
+}
+
+void
+GEOS_finish_r(GEOSContextHandle_t extHandle)
+{
+    finishGEOS_r(extHandle);
 }
 
 void 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -218,7 +218,7 @@ typedef struct GEOSContextHandle_HS
         if (noticeMessageOld) {
           noticeMessageOld("%s", msgBuffer);
         } else {
-          noticeMessageNew(this, noticeData, msgBuffer);
+          noticeMessageNew(msgBuffer, noticeData);
         }
       }
     }
@@ -239,7 +239,7 @@ typedef struct GEOSContextHandle_HS
         if (errorMessageOld) {
           errorMessageOld("%s", msgBuffer);
         } else {
-          errorMessageNew(this, errorData, msgBuffer);
+          errorMessageNew(msgBuffer, errorData);
         }
       }
     }

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -141,11 +141,9 @@ typedef struct GEOSContextHandle_HS
     GEOSMessageHandler noticeMessageOld;
     GEOSMessageHandler_r noticeMessageNew;
     void *noticeData;
-    void(*freeNoticeData)(void*);
     GEOSMessageHandler errorMessageOld;
     GEOSMessageHandler_r errorMessageNew;
     void *errorData;
-    void(*freeErrorData)(void*);
     int WKBOutputDims;
     int WKBByteOrder;
     int initialized;
@@ -161,24 +159,14 @@ typedef struct GEOSContextHandle_HS
       initialized = 1;
     }
 
-    ~ GEOSContextHandle_HS()
-    {
-      setNoticeHandler(NULL);
-      setErrorHandler(NULL);
-    }
-
     GEOSMessageHandler
     setNoticeHandler(GEOSMessageHandler nf)
     {
         GEOSMessageHandler f = noticeMessageOld;
         noticeMessageOld = nf;
         noticeMessageNew = NULL;
-        if (freeNoticeData) {
-          freeNoticeData(noticeData);
-        }
         noticeData = NULL;
-        freeNoticeData = NULL;        
-        
+
         return f;
     }
 
@@ -188,41 +176,29 @@ typedef struct GEOSContextHandle_HS
         GEOSMessageHandler f = errorMessageOld;
         errorMessageOld = nf;
         errorMessageNew = NULL;
-        if (freeErrorData) {
-          freeErrorData(errorData);
-        }
         errorData = NULL;
-        freeErrorData = NULL;        
-        
+
         return f;
     }
 
     GEOSMessageHandler_r
-    setNoticeHandler(GEOSMessageHandler_r nf, void *userData, void(*freeUserData)(void*)) {
+    setNoticeHandler(GEOSMessageHandler_r nf, void *userData) {
         GEOSMessageHandler_r f = noticeMessageNew;
         noticeMessageOld = NULL;
         noticeMessageNew = nf;
-        if (freeNoticeData) {
-          freeNoticeData(noticeData);
-        }
         noticeData = userData;
-        freeNoticeData = freeUserData;        
-        
+
         return f;
     }
 
     GEOSMessageHandler_r
-    setErrorHandler(GEOSMessageHandler_r ef, void *userData, void(*freeUserData)(void*))
+    setErrorHandler(GEOSMessageHandler_r ef, void *userData)
     {
         GEOSMessageHandler_r f = errorMessageNew;
         errorMessageOld = NULL;
         errorMessageNew = ef;
-        if (freeErrorData) {
-          freeErrorData(errorData);
-        }
         errorData = userData;
-        freeErrorData = freeUserData;        
-        
+
         return f;
     }
 
@@ -369,7 +345,7 @@ GEOSContext_setErrorHandler_r(GEOSContextHandle_t extHandle, GEOSMessageHandler 
 }
 
 GEOSMessageHandler_r
-GEOSContext_setNoticeMessageHandler_r(GEOSContextHandle_t extHandle, GEOSMessageHandler_r nf, void *userData, void(*freeUserData)(void*)) {
+GEOSContext_setNoticeMessageHandler_r(GEOSContextHandle_t extHandle, GEOSMessageHandler_r nf, void *userData) {
     GEOSContextHandleInternal_t *handle = 0;
     handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
     if ( 0 == handle->initialized )
@@ -377,11 +353,11 @@ GEOSContext_setNoticeMessageHandler_r(GEOSContextHandle_t extHandle, GEOSMessage
         return NULL;
     }
 
-    return handle->setNoticeHandler(nf, userData, freeUserData);
+    return handle->setNoticeHandler(nf, userData);
 }
 
 GEOSMessageHandler_r
-GEOSContext_setErrorMessageHandler_r(GEOSContextHandle_t extHandle, GEOSMessageHandler_r ef, void *userData, void(*freeUserData)(void*))
+GEOSContext_setErrorMessageHandler_r(GEOSContextHandle_t extHandle, GEOSMessageHandler_r ef, void *userData)
 {
     GEOSContextHandleInternal_t *handle = 0;
     handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
@@ -390,7 +366,7 @@ GEOSContext_setErrorMessageHandler_r(GEOSContextHandle_t extHandle, GEOSMessageH
         return NULL;
     }
 
-    return handle->setErrorHandler(ef, userData, freeUserData);
+    return handle->setErrorHandler(ef, userData);
 }
 
 void


### PR DESCRIPTION
Extends the C wrapper interface with a means to associate user data with the notification handlers. This enables threadsafe handling of error and notice messages on the consumer side.