### PR TITLE
Allow failure of cmake/clang/64bit build (bug outside geos, I believe)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,14 @@ compiler:
     - clang
 
 env:
-    matrix:
-        - GEOS_BUILD_TOOL=autotools CFLAGS=-m32 CXXFLAGS=-m32
-        - GEOS_BUILD_TOOL=autotools CFLAGS=-m64 CXXFLAGS=-m64
-        - GEOS_BUILD_TOOL=cmake CFLAGS=-m32 CXXFLAGS=-m32
-        - GEOS_BUILD_TOOL=cmake CFLAGS=-m64 CXXFLAGS=-m64
+    - GEOS_BUILD_TOOL=autotools CFLAGS=-m32 CXXFLAGS=-m32
+    - GEOS_BUILD_TOOL=autotools CFLAGS=-m64 CXXFLAGS=-m64
+    - GEOS_BUILD_TOOL=cmake CFLAGS=-m32 CXXFLAGS=-m32
+    - GEOS_BUILD_TOOL=cmake CFLAGS=-m64 CXXFLAGS=-m64
+
+matrix:
+    allow_failures:
+      - env: GEOS_BUILD_TOOL=cmake CFLAGS=-m64 CXXFLAGS=-m64
 
 before_install: ./tools/ci/before_install.sh
 


### PR DESCRIPTION
just a test for allowing travis failures, which we should probably not allow as it doesn't fail in 3.4...

https://travis-ci.org/libgeos/libgeos/builds/47505801
https://travis-ci.org/libgeos/libgeos/builds/48031859

\cc @mloskot ideas about the difference between 3.3 and 3.4 branch when it comes to CMake/clang/64bit ?