### PR TITLE
Add support for M values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ message(STATUS
   "Setting GEOS compilation with small functions inlining - ${GEOS_ENABLE_INLINE}")
 
 if(GEOS_ENABLE_M)
-  add_definitions(-DGEOS_MVALUES)
+  set(GEOS_MVALUES 1)
 endif()
 message(STATUS
   "Setting GEOS compilation with M support - ${GEOS_ENABLE_M}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ option(GEOS_ENABLE_TESTS
 option(GEOS_ENABLE_INLINE
   "Set to OFF|ON (default) to control GEOS compilation with small functions inlining" ON)
 
+option(GEOS_ENABLE_M
+  "Set to OFF|ON (default) to control whether geos supports M values" ON)
+
 if(NOT MSVC)
   option(GEOS_ENABLE_ASSERT
     "Set to ON|OFF (default) to build GEOS with assert() macro enabled" OFF) 
@@ -145,6 +148,12 @@ if(GEOS_ENABLE_INLINE)
 endif()
 message(STATUS
   "Setting GEOS compilation with small functions inlining - ${GEOS_ENABLE_INLINE}")
+
+if(GEOS_ENABLE_M)
+  add_definitions(-DGEOS_MVALUES)
+endif()
+message(STATUS
+  "Setting GEOS compilation with M support - ${GEOS_ENABLE_M}")
 
 if(NOT MSVC)
   if(GEOS_ENABLE_ASSERT)

--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,6 @@ MVALUES_FLAGS=
 AC_SUBST(MVALUES_FLAGS)
 if test x"$enable_mvalues" = xtrue; then
 	MVALUES_FLAGS="-DGEOS_MVALUES"
-	AM_CXXFLAGS="$AM_CXXFLAGS $MVALUES_FLAGS"
     AC_MSG_RESULT([yes])
     AC_DEFINE(GEOS_MVALUES, [1], [Has M values support])
 else

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,7 @@ if test x"$enable_mvalues" = xtrue; then
 	MVALUES_FLAGS="-DGEOS_MVALUES"
 	AM_CXXFLAGS="$AM_CXXFLAGS $MVALUES_FLAGS"
     AC_MSG_RESULT([yes])
+    AC_DEFINE(GEOS_MVALUES, [1], [Has M values support])
 else
     AC_MSG_RESULT([no])
 fi
@@ -545,6 +546,7 @@ AC_OUTPUT([
 
 dnl -- echo "---------------------------------------"
 dnl -- echo "Boost UTF: $use_boost_utf"
+echo "Enable M values: $enable_mvalues"
 echo "Swig: $use_swig"
 echo "Python bindings: $use_python"
 echo "Ruby bindings: $use_ruby"

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,15 @@ AC_ARG_ENABLE([inline], [  --disable-inline    Disable inlining],
 	[enable_inline=true]
 )
 
+AC_ARG_ENABLE([mvalues], [  --disable-mvalues    Disable M values support],
+	[case "${enableval}" in
+		yes) enable_mvalues=true ;;
+		no)  enable_mvalues=false ;;
+		*) AC_MSG_ERROR(bad value ${enableval} for --enable-mvalues);;
+	esac],
+	[enable_mvalues=true]
+)
+
 AC_ARG_ENABLE([cassert], [  --disable-cassert   Disable assertion checking],
 	[case "${enableval}" in
 		yes) enable_cassert=true ;;
@@ -108,6 +117,17 @@ AC_SUBST(INLINE_FLAGS)
 if test x"$enable_inline" = xtrue; then
 	INLINE_FLAGS="-DGEOS_INLINE"
 	AM_CXXFLAGS="$AM_CXXFLAGS $INLINE_FLAGS"
+    AC_MSG_RESULT([yes])
+else
+    AC_MSG_RESULT([no])
+fi
+
+AC_MSG_CHECKING([if requested to enable M values support])
+MVALUES_FLAGS=
+AC_SUBST(MVALUES_FLAGS)
+if test x"$enable_mvalues" = xtrue; then
+	MVALUES_FLAGS="-DGEOS_MVALUES"
+	AM_CXXFLAGS="$AM_CXXFLAGS $MVALUES_FLAGS"
     AC_MSG_RESULT([yes])
 else
     AC_MSG_RESULT([no])

--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -54,6 +54,11 @@ public:
 	/// the given point p
 	static double interpolateZ(const geom::Coordinate &p, const geom::Coordinate &p0, const geom::Coordinate &p1);
 
+	/// \brief
+	/// Return a M value being the interpolation of M from p0 and p1 at
+	/// the given point p
+	static double interpolateM(const geom::Coordinate &p, const geom::Coordinate &p0, const geom::Coordinate &p1);
+
 
 	/// Computes the "edge distance" of an intersection point p in an edge.
 	//

--- a/include/geos/algorithm/LineIntersector.h
+++ b/include/geos/algorithm/LineIntersector.h
@@ -54,10 +54,12 @@ public:
 	/// the given point p
 	static double interpolateZ(const geom::Coordinate &p, const geom::Coordinate &p0, const geom::Coordinate &p1);
 
+#ifdef GEOS_MVALUES
 	/// \brief
 	/// Return a M value being the interpolation of M from p0 and p1 at
 	/// the given point p
 	static double interpolateM(const geom::Coordinate &p, const geom::Coordinate &p0, const geom::Coordinate &p1);
+#endif
 
 
 	/// Computes the "edge distance" of an intersection point p in an edge.

--- a/include/geos/geom/Coordinate.h
+++ b/include/geos/geom/Coordinate.h
@@ -85,8 +85,10 @@ public:
 	/// z-coordinate
 	double z;
 
+#ifdef GEOS_MVALUES
 	/// m-coordinate
 	double m;
+#endif
 
 	void setNull();
 
@@ -94,7 +96,11 @@ public:
 
 	bool isNull() const;
 
+#ifdef GEOS_MVALUES
 	Coordinate(double xNew=0.0, double yNew=0.0, double zNew=DoubleNotANumber, double mNew=DoubleNotANumber);
+#else
+	Coordinate(double xNew=0.0, double yNew=0.0, double zNew=DoubleNotANumber);
+#endif
 
 	bool equals2D(const Coordinate& other) const;
 
@@ -107,11 +113,13 @@ public:
 	/// 3D XYZ comparison
 	bool equals3D(const Coordinate& other) const;
 
+#ifdef GEOS_MVALUES
 	/// 3D XYM comparison
 	bool equals3DM(const Coordinate& other) const;
 
 	/// 4D XYZM comparison
 	bool equals4D(const Coordinate& other) const;
+#endif
 
 	///  Returns a string of the form <I>(x,y,z)</I> .
 	std::string toString() const;

--- a/include/geos/geom/Coordinate.h
+++ b/include/geos/geom/Coordinate.h
@@ -85,13 +85,16 @@ public:
 	/// z-coordinate
 	double z;
 
+	/// m-coordinate
+	double m;
+
 	void setNull();
 
 	static Coordinate& getNull();
 
 	bool isNull() const;
 
-	Coordinate(double xNew=0.0, double yNew=0.0, double zNew=DoubleNotANumber);
+	Coordinate(double xNew=0.0, double yNew=0.0, double zNew=DoubleNotANumber, double mNew=DoubleNotANumber);
 
 	bool equals2D(const Coordinate& other) const;
 
@@ -101,8 +104,14 @@ public:
 	/// TODO: deprecate this, move logic to CoordinateLessThen instead
 	int compareTo(const Coordinate& other) const;
 
-	/// 3D comparison 
+	/// 3D XYZ comparison
 	bool equals3D(const Coordinate& other) const;
+
+	/// 3D XYM comparison
+	bool equals3DM(const Coordinate& other) const;
+
+	/// 4D XYZM comparison
+	bool equals4D(const Coordinate& other) const;
 
 	///  Returns a string of the form <I>(x,y,z)</I> .
 	std::string toString() const;

--- a/include/geos/geom/Coordinate.inl
+++ b/include/geos/geom/Coordinate.inl
@@ -30,20 +30,22 @@ Coordinate::setNull()
 	x=DoubleNotANumber;
 	y=DoubleNotANumber;
 	z=DoubleNotANumber;
+	m=DoubleNotANumber;
 }
 
 INLINE bool
 Coordinate::isNull() const
 {
-	return (ISNAN(x) && ISNAN(y) && ISNAN(z));
+	return (ISNAN(x) && ISNAN(y) && ISNAN(z) && ISNAN(m));
 }
 
 INLINE
-Coordinate::Coordinate(double xNew, double yNew, double zNew)
+Coordinate::Coordinate(double xNew, double yNew, double zNew, double mNew)
 	:
 	x(xNew),
 	y(yNew),
-	z(zNew)
+	z(zNew),
+	m(mNew)
 {}
 
 INLINE bool
@@ -75,6 +77,21 @@ Coordinate::equals3D(const Coordinate& other) const
 {
 	return (x == other.x) && ( y == other.y) && 
 		((z == other.z)||(ISNAN(z) && ISNAN(other.z)));
+}
+
+INLINE bool
+Coordinate::equals3DM(const Coordinate& other) const
+{
+    return (x == other.x) && ( y == other.y) &&
+        ((m == other.m)||(ISNAN(m) && ISNAN(other.m)));
+}
+
+INLINE bool
+Coordinate::equals4D(const Coordinate& other) const
+{
+    return (x == other.x) && ( y == other.y) &&
+        ((z == other.z)||(ISNAN(z) && ISNAN(other.z))) &&
+        ((m == other.m)||(ISNAN(m) && ISNAN(other.m)));
 }
 
 INLINE double

--- a/include/geos/geom/Coordinate.inl
+++ b/include/geos/geom/Coordinate.inl
@@ -30,15 +30,22 @@ Coordinate::setNull()
 	x=DoubleNotANumber;
 	y=DoubleNotANumber;
 	z=DoubleNotANumber;
+#ifdef GEOS_MVALUES
 	m=DoubleNotANumber;
+#endif
 }
 
 INLINE bool
 Coordinate::isNull() const
 {
+#ifdef GEOS_MVALUES
 	return (ISNAN(x) && ISNAN(y) && ISNAN(z) && ISNAN(m));
+#else
+	return (ISNAN(x) && ISNAN(y) && ISNAN(z));
+#endif
 }
 
+#ifdef GEOS_MVALUES
 INLINE
 Coordinate::Coordinate(double xNew, double yNew, double zNew, double mNew)
 	:
@@ -47,6 +54,15 @@ Coordinate::Coordinate(double xNew, double yNew, double zNew, double mNew)
 	z(zNew),
 	m(mNew)
 {}
+#else
+INLINE
+Coordinate::Coordinate(double xNew, double yNew, double zNew)
+	:
+	x(xNew),
+	y(yNew),
+	z(zNew)
+{}
+#endif
 
 INLINE bool
 Coordinate::equals2D(const Coordinate& other) const
@@ -79,6 +95,7 @@ Coordinate::equals3D(const Coordinate& other) const
 		((z == other.z)||(ISNAN(z) && ISNAN(other.z)));
 }
 
+#ifdef GEOS_MVALUES
 INLINE bool
 Coordinate::equals3DM(const Coordinate& other) const
 {
@@ -93,6 +110,7 @@ Coordinate::equals4D(const Coordinate& other) const
         ((z == other.z)||(ISNAN(z) && ISNAN(other.z))) &&
         ((m == other.m)||(ISNAN(m) && ISNAN(other.m)));
 }
+#endif
 
 INLINE double
 Coordinate::distance(const Coordinate& p) const

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -111,11 +111,17 @@ public:
 
 	void expandEnvelope(Envelope &env) const;
 
+#ifdef GEOS_MVALUES
 	std::size_t getDimension() const{ return 2 + getHasZ() + getHasM(); }
+#else
+	std::size_t getDimension() const{ return 2 + getHasZ(); }
+#endif
 
 	bool getHasZ() const;
 
+#ifdef GEOS_MVALUES
 	bool getHasM() const;
+#endif
 
 	void apply_rw(const CoordinateFilter *filter); 
 
@@ -126,7 +132,9 @@ public:
 private:
 	std::vector<Coordinate> *vect;
 	mutable int hasZ;
+#ifdef GEOS_MVALUES
 	mutable int hasM;
+#endif
 };
 
 /// This is for backward API compatibility

--- a/include/geos/geom/CoordinateArraySequence.h
+++ b/include/geos/geom/CoordinateArraySequence.h
@@ -63,10 +63,11 @@ public:
 
 	/// Construct sequence taking ownership of given Coordinate vector
 	CoordinateArraySequence(std::vector<Coordinate> *coords,
-                                std::size_t dimension = 0);
+	                        std::size_t dimension = 0, bool dim3isM = false);
         
 	/// Construct sequence allocating space for n coordinates
-	CoordinateArraySequence(std::size_t n, std::size_t dimension = 0);
+	CoordinateArraySequence(std::size_t n,
+	                        std::size_t dimension = 0, bool dim3isM = false);
 
 	~CoordinateArraySequence();
 
@@ -110,7 +111,11 @@ public:
 
 	void expandEnvelope(Envelope &env) const;
 
-    std::size_t getDimension() const;
+	std::size_t getDimension() const{ return 2 + getHasZ() + getHasM(); }
+
+	bool getHasZ() const;
+
+	bool getHasM() const;
 
 	void apply_rw(const CoordinateFilter *filter); 
 
@@ -120,7 +125,8 @@ public:
 
 private:
 	std::vector<Coordinate> *vect;
-    mutable std::size_t dimension;
+	mutable int hasZ;
+	mutable int hasM;
 };
 
 /// This is for backward API compatibility

--- a/include/geos/geom/CoordinateArraySequenceFactory.h
+++ b/include/geos/geom/CoordinateArraySequenceFactory.h
@@ -45,10 +45,12 @@ class GEOS_DLL CoordinateArraySequenceFactory: public CoordinateSequenceFactory 
 public:
 	CoordinateSequence *create() const;
 
-	CoordinateSequence *create(std::vector<Coordinate> *coords, std::size_t dims=0) const;
+	CoordinateSequence *create(std::vector<Coordinate> *coords,
+	                           std::size_t dimension = 0,
+	                           bool dim3isM = false) const;
 
-   	/** @see CoordinateSequenceFactory::create(std::size_t, int) */
-	CoordinateSequence *create(std::size_t size, std::size_t dimension=0) const;
+	CoordinateSequence *create(std::size_t size, std::size_t dimension = 0,
+	                           bool dim3isM = false) const;
 
 	CoordinateSequence *create(const CoordinateSequence &coordSeq) const;
 

--- a/include/geos/geom/CoordinateArraySequenceFactory.inl
+++ b/include/geos/geom/CoordinateArraySequenceFactory.inl
@@ -26,21 +26,23 @@ INLINE CoordinateSequence *
 CoordinateArraySequenceFactory::create() const
 {
     return new CoordinateArraySequence(
-                reinterpret_cast<std::vector<Coordinate>*>(0), 0);
+                reinterpret_cast<std::vector<Coordinate>*>(0), 0, false);
 }
 
 INLINE CoordinateSequence *
 CoordinateArraySequenceFactory::create(std::vector<Coordinate> *coords,
-		size_t dimension ) const
+                                       std::size_t dimension,
+                                       bool dim3isM) const
 {
-	return new CoordinateArraySequence(coords,dimension);
+	return new CoordinateArraySequence(coords, dimension, dim3isM);
 }
 
 INLINE CoordinateSequence *
-CoordinateArraySequenceFactory::create(std::size_t size, std::size_t dimension)
-		const
+CoordinateArraySequenceFactory::create(std::size_t size,
+                                       std::size_t dimension,
+                                       bool dim3isM) const
 {
-	return new CoordinateArraySequence(size,dimension);
+	return new CoordinateArraySequence(size, dimension, dim3isM);
 }
 
 INLINE CoordinateSequence *

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -299,7 +299,11 @@ public:
 	static void reverse(CoordinateSequence *cl);
 
 	/// Standard ordinate index values
+#ifdef GEOS_MVALUES
 	enum { X,Y,Z,M };
+#else
+	enum { X,Y,Z };
+#endif
 
 	/**
 	 * Returns the dimension (number of ordinates in each coordinate)
@@ -316,12 +320,14 @@ public:
 	 */
 	virtual bool getHasZ() const=0;
 
+#ifdef GEOS_MVALUES
 	/**
 	 * Returns whether the coordinates in this sequence have a M value.
 	 *
 	 * @return whether the coordinates in this sequence have a M value.
 	 */
 	virtual bool getHasM() const=0;
+#endif
 
 	/**
 	 * Returns the ordinate of a coordinate in this sequence.

--- a/include/geos/geom/CoordinateSequence.h
+++ b/include/geos/geom/CoordinateSequence.h
@@ -310,6 +310,20 @@ public:
 	virtual std::size_t getDimension() const=0;
 
 	/**
+	 * Returns whether the coordinates in this sequence have a Z value.
+	 *
+	 * @return whether the coordinates in this sequence have a Z value.
+	 */
+	virtual bool getHasZ() const=0;
+
+	/**
+	 * Returns whether the coordinates in this sequence have a M value.
+	 *
+	 * @return whether the coordinates in this sequence have a M value.
+	 */
+	virtual bool getHasM() const=0;
+
+	/**
 	 * Returns the ordinate of a coordinate in this sequence.
 	 * Ordinate indices 0 and 1 are assumed to be X and Y.
 	 * Ordinates indices greater than 1 have user-defined semantics

--- a/include/geos/geom/CoordinateSequenceFactory.h
+++ b/include/geos/geom/CoordinateSequenceFactory.h
@@ -69,7 +69,7 @@ public:
 	 * @param dimension the dimension of the coordinates in the sequence
 	 * 	(0=unknown, 2, 3 or 4 - ignored if not user specifiable)
 	 * @param dim3isM only if dimension=3, specifies whether dim 3 is Z or M
-	 * 	(0=false, 1=true)
+	 * 	(0=false, 1=true). Ignored if GEOS compiled without M support.
 	 */
 	virtual CoordinateSequence *create( std::vector<Coordinate> *coordinates,
 	                                    std::size_t dimension = 0,
@@ -85,7 +85,7 @@ public:
 	 * @param dimension the dimension of the coordinates in the sequence
 	 * 	(0=unknown, 2, 3 or 4 - ignored if not user specifiable)
 	 * @param dim3isM only if dimension=3, specifies whether dim 3 is Z or M
-	 * 	(0=false, 1=true)
+	 * 	(0=false, 1=true). Ignored if GEOS compiled without M support.
 	 */
 	virtual CoordinateSequence *create( std::size_t size,
 	                                    std::size_t dimension = 0,

--- a/include/geos/geom/CoordinateSequenceFactory.h
+++ b/include/geos/geom/CoordinateSequenceFactory.h
@@ -66,11 +66,14 @@ public:
 	 * an empty sequence.
 	 *
 	 * @param coordinates the coordinates
-     * @param dimension 0, 2 or 3 with 0 indicating unknown at this time.
+	 * @param dimension the dimension of the coordinates in the sequence
+	 * 	(0=unknown, 2, 3 or 4 - ignored if not user specifiable)
+	 * @param dim3isM only if dimension=3, specifies whether dim 3 is Z or M
+	 * 	(0=false, 1=true)
 	 */
-	virtual CoordinateSequence *create(
-            std::vector<Coordinate> *coordinates,
-            std::size_t dimension=0 ) const=0;
+	virtual CoordinateSequence *create( std::vector<Coordinate> *coordinates,
+	                                    std::size_t dimension = 0,
+	                                    bool dim3isM = false ) const=0;
 
 	/** \brief
 	 * Creates a CoordinateSequence of the specified size and dimension.
@@ -80,10 +83,13 @@ public:
 	 *
 	 * @param size the number of coordinates in the sequence
 	 * @param dimension the dimension of the coordinates in the sequence
-	 * 	(0=unknown, 2, or 3 - ignored if not user specifiable)
+	 * 	(0=unknown, 2, 3 or 4 - ignored if not user specifiable)
+	 * @param dim3isM only if dimension=3, specifies whether dim 3 is Z or M
+	 * 	(0=false, 1=true)
 	 */
-	virtual CoordinateSequence *create(std::size_t size,
-                                           std::size_t dimension=0) const=0;
+	virtual CoordinateSequence *create( std::size_t size,
+	                                    std::size_t dimension = 0,
+	                                    bool dim3isM = false) const=0;
 
 	/** \brief
 	 * Creates a CoordinateSequence which is a copy of the given one.

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -307,8 +307,10 @@ public:
 	/// Returns whether this Geometry has Z values.
 	virtual bool getHasZ() const=0;
 
+#ifdef GEOS_MVALUES
 	/// Returns whether this Geometry has M values.
 	virtual bool getHasM() const=0;
+#endif
 
 	/**
 	 * \brief

--- a/include/geos/geom/Geometry.h
+++ b/include/geos/geom/Geometry.h
@@ -300,8 +300,15 @@ public:
 	/// Returns the dimension of this Geometry (0=point, 1=line, 2=surface)
 	virtual Dimension::DimensionType getDimension() const=0; //Abstract
 
-	/// Returns the coordinate dimension of this Geometry (2=XY, 3=XYZ, 4=XYZM in future).
+	/// Returns the coordinate dimension of this Geometry (2=XY, 3=XYZ or XYM, 4=XYZM).
+	/// @see getHasZ and getHasM to distinguish between XYZ and XYM.
 	virtual int getCoordinateDimension() const=0; //Abstract
+
+	/// Returns whether this Geometry has Z values.
+	virtual bool getHasZ() const=0;
+
+	/// Returns whether this Geometry has M values.
+	virtual bool getHasM() const=0;
 
 	/**
 	 * \brief

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -106,6 +106,8 @@ public:
 
 	/// Returns coordinate dimension.
 	virtual int getCoordinateDimension() const;
+	virtual bool getHasZ() const;
+	virtual bool getHasM() const;
 
 	virtual Geometry* getBoundary() const;
 

--- a/include/geos/geom/GeometryCollection.h
+++ b/include/geos/geom/GeometryCollection.h
@@ -107,7 +107,9 @@ public:
 	/// Returns coordinate dimension.
 	virtual int getCoordinateDimension() const;
 	virtual bool getHasZ() const;
+#ifdef GEOS_MVALUES
 	virtual bool getHasM() const;
+#endif
 
 	virtual Geometry* getBoundary() const;
 

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -106,7 +106,9 @@ public:
 	/// Returns coordinate dimension.
 	virtual int getCoordinateDimension() const;
 	virtual bool getHasZ() const;
+#ifdef GEOS_MVALUES
 	virtual bool getHasM() const;
+#endif
 
 	/**
 	 * \brief

--- a/include/geos/geom/LineString.h
+++ b/include/geos/geom/LineString.h
@@ -105,6 +105,8 @@ public:
 
 	/// Returns coordinate dimension.
 	virtual int getCoordinateDimension() const;
+	virtual bool getHasZ() const;
+	virtual bool getHasM() const;
 
 	/**
 	 * \brief

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -97,6 +97,8 @@ public:
 
 	/// Returns coordinate dimension.
 	virtual int getCoordinateDimension() const;
+	virtual bool getHasZ() const;
+	virtual bool getHasM() const;
 
 	/// Returns Dimension::False (Point has no boundary)
 	int getBoundaryDimension() const;

--- a/include/geos/geom/Point.h
+++ b/include/geos/geom/Point.h
@@ -98,7 +98,9 @@ public:
 	/// Returns coordinate dimension.
 	virtual int getCoordinateDimension() const;
 	virtual bool getHasZ() const;
+#ifdef GEOS_MVALUES
 	virtual bool getHasM() const;
+#endif
 
 	/// Returns Dimension::False (Point has no boundary)
 	int getBoundaryDimension() const;

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -92,6 +92,8 @@ public:
 
 	/// Returns coordinate dimension.
 	virtual int getCoordinateDimension() const;
+	virtual bool getHasZ() const;
+	virtual bool getHasM() const;
 
 	/// Returns 1 (Polygon boundary is a MultiLineString)
 	int getBoundaryDimension() const;

--- a/include/geos/geom/Polygon.h
+++ b/include/geos/geom/Polygon.h
@@ -93,7 +93,9 @@ public:
 	/// Returns coordinate dimension.
 	virtual int getCoordinateDimension() const;
 	virtual bool getHasZ() const;
+#ifdef GEOS_MVALUES
 	virtual bool getHasM() const;
+#endif
 
 	/// Returns 1 (Polygon boundary is a MultiLineString)
 	int getBoundaryDimension() const;

--- a/include/geos/geomgraph/Node.h
+++ b/include/geos/geomgraph/Node.h
@@ -113,10 +113,14 @@ public:
 	virtual std::string print();
 
 	virtual const std::vector<double> &getZ() const;
+#ifdef GEOS_MVALUES
 	virtual const std::vector<double> &getM() const;
+#endif
 
 	virtual void addZ(double);
+#ifdef GEOS_MVALUES
 	virtual void addM(double);
+#endif
 
 	/** \brief
 	 * Tests whether any incident edge is flagged as

--- a/include/geos/geomgraph/Node.h
+++ b/include/geos/geomgraph/Node.h
@@ -113,8 +113,10 @@ public:
 	virtual std::string print();
 
 	virtual const std::vector<double> &getZ() const;
+	virtual const std::vector<double> &getM() const;
 
 	virtual void addZ(double);
+	virtual void addM(double);
 
 	/** \brief
 	 * Tests whether any incident edge is flagged as
@@ -145,8 +147,10 @@ protected:
 private:
 
 	std::vector<double> zvals;
+	std::vector<double> mvals;
 
 	double ztot;
+	double mtot;
 
 };
 

--- a/include/geos/io/WKBReader.h
+++ b/include/geos/io/WKBReader.h
@@ -119,8 +119,8 @@ private:
 
 	const geom::GeometryFactory &factory;
 
-	// for now support the WKB standard only - may be generalized later
-	unsigned int inputDimension;
+	bool hasZ;
+	bool hasM;
 
 	ByteOrderDataInStream dis;
 

--- a/include/geos/io/WKBWriter.h
+++ b/include/geos/io/WKBWriter.h
@@ -102,11 +102,19 @@ public:
 	/*
 	 * Sets the output dimension used by the <code>WKBWriter</code>.  
 	 *
-	 * @param newOutputDimension Supported values are 2 or 3. 
-	 * Note that 3 indicates up to 3 dimensions will be written but
-	 * 2D WKB is still produced for 2D geometries.
+	 * @param newOutputDimension Supported values are 2, 3 or 4.
+	 *        If the geometry has XYZ values, 3 indicates that a 3D WKT will be
+	 *        produced.
+	 *        If the geometry has XYM values, 3 indicates that a 2D-M WKT will
+	 *        be produced.
+	 *        If the geometry has XYZM values, 3 indicates that a 3D WKT will
+	 *        be produced, unless preferM = true.
+	 *        If the geometry has only XY values, a 2D WKT will be produced
+	 *        regardless of the passed value.
+	 * @param preferM Whether to write M values instead of Z values if
+	 *                newOutputDimensions = 3 and geometry has XYZM values.
 	 */
-	virtual void setOutputDimension(int newOutputDimension);
+	virtual void setOutputDimension(int newOutputDimension, bool preferM = false);
 	
 	/*
 	 * \brief
@@ -157,7 +165,9 @@ public:
 private:
 
 	int defaultOutputDimension;
-    int outputDimension;
+	bool defaultOutputPreferM;
+	bool outputZ;
+	bool outputM;
 
 	int byteOrder;
 	
@@ -182,7 +192,7 @@ private:
 	void writeCoordinateSequence(const geom::CoordinateSequence &cs, bool sized);
 		// throws IOException
 
-	void writeCoordinate(const geom::CoordinateSequence &cs, int idx, bool is3d);
+	void writeCoordinate(const geom::CoordinateSequence &cs, int idx);
 		// throws IOException
 
 	void writeGeometryType(int geometryType, int SRID);

--- a/include/geos/io/WKTReader.h
+++ b/include/geos/io/WKTReader.h
@@ -88,7 +88,7 @@ public:
 protected:
 	geom::CoordinateSequence* getCoordinates(io::StringTokenizer *tokenizer);
 	double getNextNumber(io::StringTokenizer *tokenizer);
-	std::string getNextEmptyOrOpener(io::StringTokenizer *tokenizer);
+	std::string getNextDimensionalityOrOpener(io::StringTokenizer *tokenizer, bool& hasZ, bool& hasM);
 	std::string getNextCloserOrComma(io::StringTokenizer *tokenizer);
 	std::string getNextCloser(io::StringTokenizer *tokenizer);
 	std::string getNextWord(io::StringTokenizer *tokenizer);
@@ -105,7 +105,7 @@ private:
 	const geom::GeometryFactory *geometryFactory;
 	const geom::PrecisionModel *precisionModel;
 
-	void getPreciseCoordinate(io::StringTokenizer *tokenizer, geom::Coordinate&, std::size_t &dim );
+	void getPreciseCoordinate(io::StringTokenizer *tokenizer, geom::Coordinate&, bool& hasZ , bool hasM);
 
 	bool isNumberNext(io::StringTokenizer *tokenizer);
 };

--- a/include/geos/io/WKTWriter.h
+++ b/include/geos/io/WKTWriter.h
@@ -161,11 +161,19 @@ public:
 	/*
 	 * Sets the output dimension used by the <code>WKBWriter</code>.  
 	 *
-	 * @param newOutputDimension Supported values are 2 or 3. 
-	 *        Note that 3 indicates up to 3 dimensions will be
-	 *        written but 2D WKB is still produced for 2D geometries.
+	 * @param newOutputDimension Supported values are 2, 3 or 4.
+	 *        If the geometry has XYZ values, 3 indicates that a 3DZ WKT will be
+	 *        produced.
+	 *        If the geometry has XYM values, 3 indicates that a 3DM WKT will
+	 *        be produced.
+	 *        If the geometry has XYZM values, 3 indicates that a 3DZ WKT will
+	 *        be produced, unless preferM = true.
+	 *        If the geometry has only XY values, a 2D WKT will be produced
+	 *        regardless of the passed value.
+	 * @param preferM Whether to write M values instead of Z values if
+	 *                newOutputDimensions = 3 and geometry has XYZM values.
 	 */
-	void setOutputDimension(int newOutputDimension);
+	void setOutputDimension(int newOutputDimension, bool preferM = false);
 	
 protected:
 
@@ -254,7 +262,9 @@ private:
 	int level;
 
 	int defaultOutputDimension;
-    int outputDimension;
+	bool defaultOutputPreferM;
+	bool outputZ;
+	bool outputM;
     bool old3D;
 
 	void writeFormatted(

--- a/include/geos/operation/overlay/LineBuilder.h
+++ b/include/geos/operation/overlay/LineBuilder.h
@@ -127,6 +127,14 @@ private:
 	 * from a 3d vertex to the end.
 	 */
 	void propagateZ(geom::CoordinateSequence *cs);
+
+	/*
+	 * If the given CoordinateSequence has mixed m and m-less vertexes
+	 * set M for all vertexes missing it.
+	 * The M value is interpolated between m vertexes and copied
+	 * from a m vertex to the end.
+	 */
+	void propagateM(geom::CoordinateSequence *cs);
 };
 
 } // namespace geos::operation::overlay

--- a/include/geos/operation/overlay/LineBuilder.h
+++ b/include/geos/operation/overlay/LineBuilder.h
@@ -128,6 +128,7 @@ private:
 	 */
 	void propagateZ(geom::CoordinateSequence *cs);
 
+#ifdef GEOS_MVALUES
 	/*
 	 * If the given CoordinateSequence has mixed m and m-less vertexes
 	 * set M for all vertexes missing it.
@@ -135,6 +136,7 @@ private:
 	 * from a m vertex to the end.
 	 */
 	void propagateM(geom::CoordinateSequence *cs);
+#endif
 };
 
 } // namespace geos::operation::overlay

--- a/include/geos/operation/overlay/OverlayOp.h
+++ b/include/geos/operation/overlay/OverlayOp.h
@@ -353,6 +353,7 @@ private:
 	 */
 	int mergeZ(geomgraph::Node *n, const geom::LineString *line) const;
 
+#ifdef GEOS_MVALUES
 	/** \brief
 	 * Merge M values of node with those of the segment or vertex in
 	 * the given Polygon it is on.
@@ -365,6 +366,7 @@ private:
 	 * @returns 1 if an intersection is found, 0 otherwise.
 	 */
 	int mergeM(geomgraph::Node *n, const geom::LineString *line) const;
+#endif
 
 	/**
 	 * Average Z of input geometries
@@ -375,6 +377,7 @@ private:
 	double getAverageZ(int targetIndex);
 	static double getAverageZ(const geom::Polygon *poly);
 
+#ifdef GEOS_MVALUES
 	/**
 	 * Average M of input geometries
 	 */
@@ -383,6 +386,7 @@ private:
 
 	double getAverageM(int targetIndex);
 	static double getAverageM(const geom::Polygon *poly);
+#endif
 
 	ElevationMatrix *elevationMatrix;
 

--- a/include/geos/operation/overlay/OverlayOp.h
+++ b/include/geos/operation/overlay/OverlayOp.h
@@ -353,6 +353,19 @@ private:
 	 */
 	int mergeZ(geomgraph::Node *n, const geom::LineString *line) const;
 
+	/** \brief
+	 * Merge M values of node with those of the segment or vertex in
+	 * the given Polygon it is on.
+	 */
+	int mergeM(geomgraph::Node *n, const geom::Polygon *poly) const;
+
+	/**
+	 * Merge M values of node with those of the segment or vertex in
+	 * the given LineString it is on.
+	 * @returns 1 if an intersection is found, 0 otherwise.
+	 */
+	int mergeM(geomgraph::Node *n, const geom::LineString *line) const;
+
 	/**
 	 * Average Z of input geometries
 	 */
@@ -361,6 +374,15 @@ private:
 
 	double getAverageZ(int targetIndex);
 	static double getAverageZ(const geom::Polygon *poly);
+
+	/**
+	 * Average M of input geometries
+	 */
+	double avgm[2];
+	bool avgmcomputed[2];
+
+	double getAverageM(int targetIndex);
+	static double getAverageM(const geom::Polygon *poly);
 
 	ElevationMatrix *elevationMatrix;
 

--- a/include/geos/platform.h.cmake
+++ b/include/geos/platform.h.cmake
@@ -61,6 +61,9 @@
 /* Set to 1 if Visual C++ finite is defined */
 #cmakedefine HAVE_FINITE 1
 
+/* Set to 1 if M values are supported */
+#cmakedefine GEOS_MVALUES
+
 
 #ifdef HAVE_IEEEFP_H
 extern "C"

--- a/include/geos/platform.h.in
+++ b/include/geos/platform.h.in
@@ -13,6 +13,9 @@
 /* Set to 1 if you have ieeefp.h */
 #undef HAVE_IEEEFP_H
 
+/* Set to 1 if M values are supported */
+#undef GEOS_MVALUES
+
 /* Has finite */
 #undef HAVE_FINITE
 

--- a/include/geos/triangulate/quadedge/Vertex.h
+++ b/include/geos/triangulate/quadedge/Vertex.h
@@ -75,7 +75,9 @@ public:
 
 	Vertex(double _x, double _y, double _z);
 
+#ifdef GEOS_MVALUES
 	Vertex(double _x, double _y, double _z, double _m);
+#endif
 
 	Vertex(const geom::Coordinate &_p);
 
@@ -93,17 +95,21 @@ public:
 		return p.z;
 	}
 
+#ifdef GEOS_MVALUES
 	inline double getM() const {
 		return p.m;
 	}
+#endif
 
 	inline void setZ(double _z) {
 		p.z = _z;
 	}
 
+#ifdef GEOS_MVALUES
 	inline void setM(double _m) {
 		p.m = _m;
 	}
+#endif
 
 	inline const geom::Coordinate& getCoordinate() const {
 		return p;
@@ -274,6 +280,7 @@ private:
 	static double interpolateZ(const geom::Coordinate &p, const geom::Coordinate &p0, 
 			const geom::Coordinate &p1);
 
+#ifdef GEOS_MVALUES
 	/**
 	 * For this vertex enclosed in a triangle defined by three verticies v0, v1 and v2, interpolate
 	 * a m value from the surrounding vertices.
@@ -297,6 +304,7 @@ private:
 	 */
 	static double interpolateM(const geom::Coordinate &p, const geom::Coordinate &p0,
 			const geom::Coordinate &p1);
+#endif
 };
 
 inline bool operator<(const Vertex& v1, const Vertex& v2) {

--- a/include/geos/triangulate/quadedge/Vertex.h
+++ b/include/geos/triangulate/quadedge/Vertex.h
@@ -75,6 +75,8 @@ public:
 
 	Vertex(double _x, double _y, double _z);
 
+	Vertex(double _x, double _y, double _z, double _m);
+
 	Vertex(const geom::Coordinate &_p);
 
 	Vertex();
@@ -91,8 +93,16 @@ public:
 		return p.z;
 	}
 
+	inline double getM() const {
+		return p.m;
+	}
+
 	inline void setZ(double _z) {
 		p.z = _z;
+	}
+
+	inline void setM(double _m) {
+		p.m = _m;
 	}
 
 	inline const geom::Coordinate& getCoordinate() const {
@@ -262,6 +272,30 @@ private:
 	 * @return
 	 */
 	static double interpolateZ(const geom::Coordinate &p, const geom::Coordinate &p0, 
+			const geom::Coordinate &p1);
+
+	/**
+	 * For this vertex enclosed in a triangle defined by three verticies v0, v1 and v2, interpolate
+	 * a m value from the surrounding vertices.
+	 */
+	virtual double interpolateMValue(const Vertex &v0, const Vertex &v1,
+			const Vertex &v2) const;
+
+	/**
+	 * Interpolates the m value of a point enclosed in a triangle.
+	 */
+	static double interpolateM(const geom::Coordinate &p, const geom::Coordinate &v0,
+			const geom::Coordinate &v1, const geom::Coordinate &v2);
+
+	/**
+	 * Computes the interpolated M-value for a point p lying on the segment p0-p1
+	 *
+	 * @param p
+	 * @param p0
+	 * @param p1
+	 * @return
+	 */
+	static double interpolateM(const geom::Coordinate &p, const geom::Coordinate &p0,
 			const geom::Coordinate &p1);
 };
 

--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -47,9 +47,13 @@
 #define COMPUTE_Z 1
 #endif // COMPUTE_Z
 
-#ifndef COMPUTE_M
-#define COMPUTE_M 1
-#endif // COMPUTE_M
+#ifdef GEOS_MVALUES
+# ifndef COMPUTE_M
+#  define COMPUTE_M 1
+# endif // COMPUTE_M
+#else
+# undef COMPUTE_M
+#endif
 
 using namespace std;
 
@@ -331,6 +335,7 @@ LineIntersector::interpolateZ(const Coordinate &p,
 
 }
 
+#ifdef GEOS_MVALUES
 /*public static*/
 double
 LineIntersector::interpolateM(const Coordinate &p,
@@ -397,7 +402,7 @@ LineIntersector::interpolateM(const Coordinate &p,
 	return interpolated;
 
 }
-
+#endif
 
 /*public*/
 void

--- a/src/algorithm/LineIntersector.cpp
+++ b/src/algorithm/LineIntersector.cpp
@@ -47,6 +47,10 @@
 #define COMPUTE_Z 1
 #endif // COMPUTE_Z
 
+#ifndef COMPUTE_M
+#define COMPUTE_M 1
+#endif // COMPUTE_M
+
 using namespace std;
 
 using namespace geos::geom;
@@ -327,6 +331,73 @@ LineIntersector::interpolateZ(const Coordinate &p,
 
 }
 
+/*public static*/
+double
+LineIntersector::interpolateM(const Coordinate &p,
+	const Coordinate &p1, const Coordinate &p2)
+{
+#if GEOS_DEBUG
+	cerr<<"LineIntersector::interpolateM("<<p.toString()<<", "<<p1.toString()<<", "<<p2.toString()<<")"<<endl;
+#endif
+
+	if ( ISNAN(p1.m) )
+	{
+#if GEOS_DEBUG
+		cerr<<" p1 do not have a M"<<endl;
+#endif
+		return p2.m; // might be DoubleNotANumber again
+	}
+
+	if ( ISNAN(p2.m) )
+	{
+#if GEOS_DEBUG
+		cerr<<" p2 do not have a M"<<endl;
+#endif
+		return p1.m; // might be DoubleNotANumber again
+	}
+
+	if (p==p1)
+	{
+#if GEOS_DEBUG
+		cerr<<" p==p1, returning "<<p1.m<<endl;
+#endif
+		return p1.m;
+	}
+	if (p==p2)
+	{
+#if GEOS_DEBUG
+		cerr<<" p==p2, returning "<<p2.m<<endl;
+#endif
+		return p2.m;
+	}
+
+	//double mgap = fabs(p2.m - p1.m);
+	double mgap = p2.m - p1.m;
+	if ( ! mgap )
+	{
+#if GEOS_DEBUG
+		cerr<<" no mgap, returning "<<p2.m<<endl;
+#endif
+		return p2.m;
+	}
+	double xoff = (p2.x-p1.x);
+	double yoff = (p2.y-p1.y);
+	double seglen = (xoff*xoff+yoff*yoff);
+	xoff = (p.x-p1.x);
+	yoff = (p.y-p1.y);
+	double pdist = (xoff*xoff+yoff*yoff);
+	double fract = sqrt(pdist/seglen);
+	double moff = mgap*fract;
+	//double interpolated = p1.m < p2.m ? p1.m+moff : p1.m-moff;
+	double interpolated = p1.m+moff;
+#if GEOS_DEBUG
+	cerr<<" mgap:"<<mgap<<" seglen:"<<seglen<<" pdist:"<<pdist
+		<<" fract:"<<fract<<" m:"<<interpolated<<endl;
+#endif
+	return interpolated;
+
+}
+
 
 /*public*/
 void
@@ -343,8 +414,8 @@ LineIntersector::computeIntersection(const Coordinate& p,const Coordinate& p1,co
 			{
 				isProperVar=false;
 			}
-#if COMPUTE_Z
 			intPt[0]=p;
+#if COMPUTE_Z
 #if GEOS_DEBUG
 			cerr<<"RobustIntersector::computeIntersection(Coordinate,Coordinate,Coordinate) calling interpolateZ"<<endl;
 #endif
@@ -357,6 +428,19 @@ LineIntersector::computeIntersection(const Coordinate& p,const Coordinate& p1,co
 					intPt[0].z = (intPt[0].z+z)/2;
 			}
 #endif // COMPUTE_Z
+#if COMPUTE_M
+#if GEOS_DEBUG
+			cerr<<"RobustIntersector::computeIntersection(Coordinate,Coordinate,Coordinate) calling interpolateZ"<<endl;
+#endif
+			double m = interpolateM(p, p1, p2);
+			if ( !ISNAN(m) )
+			{
+				if ( ISNAN(intPt[0].m) )
+					intPt[0].m = m;
+				else
+					intPt[0].m = (intPt[0].m+m)/2;
+			}
+#endif // COMPUTE_M
 			result=POINT_INTERSECTION;
 			return;
 		}
@@ -446,8 +530,12 @@ LineIntersector::computeIntersect(const Coordinate& p1,const Coordinate& p2,cons
 	 */
 	if (Pq1==0 || Pq2==0 || Qp1==0 || Qp2==0) {
 #if COMPUTE_Z
-		int hits=0;
+		int hitsz=0;
 		double z=0.0;
+#endif
+#if COMPUTE_M
+		int hitsm=0;
+		double m=0.0;
 #endif
 		isProperVar=false;
 
@@ -474,7 +562,14 @@ LineIntersector::computeIntersect(const Coordinate& p1,const Coordinate& p2,cons
 			if ( !ISNAN(p1.z) )
 			{
 				z += p1.z;
-				hits++;
+				hitsz++;
+			}
+#endif
+#if COMPUTE_M
+			if ( !ISNAN(p1.m) )
+			{
+				m += p1.m;
+				hitsm++;
 			}
 #endif
 		}
@@ -484,7 +579,14 @@ LineIntersector::computeIntersect(const Coordinate& p1,const Coordinate& p2,cons
 			if ( !ISNAN(p2.z) )
 			{
 				z += p2.z;
-				hits++;
+				hitsz++;
+			}
+#endif
+#if COMPUTE_M
+			if ( !ISNAN(p2.m) )
+			{
+				m += p2.m;
+				hitsm++;
 			}
 #endif
 		}
@@ -498,7 +600,14 @@ LineIntersector::computeIntersect(const Coordinate& p1,const Coordinate& p2,cons
 			if ( !ISNAN(q1.z) )
 			{
 				z += q1.z;
-				hits++;
+				hitsz++;
+			}
+#endif
+#if COMPUTE_M
+			if ( !ISNAN(q1.m) )
+			{
+				m += q1.m;
+				hitsm++;
 			}
 #endif
 		}
@@ -508,7 +617,14 @@ LineIntersector::computeIntersect(const Coordinate& p1,const Coordinate& p2,cons
 			if ( !ISNAN(q2.z) )
 			{
 				z += q2.z;
-				hits++;
+				hitsz++;
+			}
+#endif
+#if COMPUTE_M
+			if ( !ISNAN(q2.m) )
+			{
+				m += q2.m;
+				hitsm++;
 			}
 #endif
 		}
@@ -518,7 +634,14 @@ LineIntersector::computeIntersect(const Coordinate& p1,const Coordinate& p2,cons
 			if ( !ISNAN(p1.z) )
 			{
 				z += p1.z;
-				hits++;
+				hitsz++;
+			}
+#endif
+#if COMPUTE_M
+			if ( !ISNAN(p1.m) )
+			{
+				m += p1.m;
+				hitsm++;
 			}
 #endif
 		}
@@ -528,16 +651,29 @@ LineIntersector::computeIntersect(const Coordinate& p1,const Coordinate& p2,cons
 			if ( !ISNAN(p2.z) )
 			{
 				z += p2.z;
-				hits++;
+				hitsz++;
+			}
+#endif
+#if COMPUTE_M
+			if ( !ISNAN(p2.m) )
+			{
+				m += p2.m;
+				hitsm++;
 			}
 #endif
 		}
 #if COMPUTE_Z
 #if GEOS_DEBUG
-		cerr<<"LineIntersector::computeIntersect: z:"<<z<<" hits:"<<hits<<endl;
+		cerr<<"LineIntersector::computeIntersect: z:"<<z<<" hits:"<<hitsz<<endl;
 #endif // GEOS_DEBUG
-		if ( hits ) intPt[0].z = z/hits;
+		if ( hitsz ) intPt[0].z = z/hitsz;
 #endif // COMPUTE_Z
+#if COMPUTE_M
+#if GEOS_DEBUG
+		cerr<<"LineIntersector::computeIntersect: m:"<<m<<" hits:"<<hitsm<<endl;
+#endif // GEOS_DEBUG
+		if ( hitsm ) intPt[0].m = m/hitsm;
+#endif // COMPUTE_M
 	} else {
 		isProperVar=true;
 		intersection(p1, p2, q1, q2, intPt[0]);
@@ -554,12 +690,20 @@ LineIntersector::computeCollinearIntersection(const Coordinate& p1,const Coordin
 {
 #if COMPUTE_Z
 	double ztot;
-	int hits;
+	int hitsz;
 	double p2z;
 	double p1z;
 	double q1z;
 	double q2z;
-#endif // COMPUTE_Z
+#endif // COMPUTE_M
+#if COMPUTE_M
+	double mtot;
+	int hitsm;
+	double p2m;
+	double p1m;
+	double q1m;
+	double q2m;
+#endif // COMPUTE_M
 
 #if GEOS_DEBUG
 	cerr<<"LineIntersector::computeCollinearIntersection called"<<endl;
@@ -578,20 +722,36 @@ LineIntersector::computeCollinearIntersection(const Coordinate& p1,const Coordin
 		intPt[0]=q1;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		q1z = interpolateZ(q1, p1, p2);
-		if (!ISNAN(q1z)) { ztot+=q1z; hits++; }
-		if (!ISNAN(q1.z)) { ztot+=q1.z; hits++; }
-		if ( hits ) intPt[0].z = ztot/hits;
+		if (!ISNAN(q1z)) { ztot+=q1z; hitsz++; }
+		if (!ISNAN(q1.z)) { ztot+=q1.z; hitsz++; }
+		if ( hitsz ) intPt[0].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		q1m = interpolateM(q1, p1, p2);
+		if (!ISNAN(q1m)) { mtot+=q1m; hitsm++; }
+		if (!ISNAN(q1.m)) { mtot+=q1.m; hitsm++; }
+		if ( hitsm ) intPt[0].m = mtot/hitsm;
 #endif
 		intPt[1]=q2;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		q2z = interpolateZ(q2, p1, p2);
-		if (!ISNAN(q2z)) { ztot+=q2z; hits++; }
-		if (!ISNAN(q2.z)) { ztot+=q2.z; hits++; }
-		if ( hits ) intPt[1].z = ztot/hits;
+		if (!ISNAN(q2z)) { ztot+=q2z; hitsz++; }
+		if (!ISNAN(q2.z)) { ztot+=q2.z; hitsz++; }
+		if ( hitsz ) intPt[1].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		q2m = interpolateM(q2, p1, p2);
+		if (!ISNAN(q2m)) { mtot+=q2m; hitsm++; }
+		if (!ISNAN(q2.m)) { mtot+=q2.m; hitsm++; }
+		if ( hitsm ) intPt[1].m = mtot/hitsm;
 #endif
 #if GEOS_DEBUG
 		cerr<<" intPt[0]: "<<intPt[0].toString()<<endl;
@@ -606,20 +766,36 @@ LineIntersector::computeCollinearIntersection(const Coordinate& p1,const Coordin
 		intPt[0]=p1;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		p1z = interpolateZ(p1, q1, q2);
-		if (!ISNAN(p1z)) { ztot+=p1z; hits++; }
-		if (!ISNAN(p1.z)) { ztot+=p1.z; hits++; }
-		if ( hits ) intPt[0].z = ztot/hits;
+		if (!ISNAN(p1z)) { ztot+=p1z; hitsz++; }
+		if (!ISNAN(p1.z)) { ztot+=p1.z; hitsz++; }
+		if ( hitsz ) intPt[0].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		p1m = interpolateM(p1, q1, q2);
+		if (!ISNAN(p1m)) { mtot+=p1m; hitsm++; }
+		if (!ISNAN(p1.m)) { mtot+=p1.m; hitsm++; }
+		if ( hitsm ) intPt[0].m = mtot/hitsm;
 #endif
 		intPt[1]=p2;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		p2z = interpolateZ(p2, q1, q2);
-		if (!ISNAN(p2z)) { ztot+=p2z; hits++; }
-		if (!ISNAN(p2.z)) { ztot+=p2.z; hits++; }
-		if ( hits ) intPt[1].z = ztot/hits;
+		if (!ISNAN(p2z)) { ztot+=p2z; hitsz++; }
+		if (!ISNAN(p2.z)) { ztot+=p2.z; hitsz++; }
+		if ( hitsz ) intPt[1].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		p2m = interpolateM(p2, q1, q2);
+		if (!ISNAN(p2m)) { mtot+=p2m; hitsm++; }
+		if (!ISNAN(p2.m)) { mtot+=p2.m; hitsm++; }
+		if ( hitsm ) intPt[1].m = mtot/hitsm;
 #endif
 		return COLLINEAR_INTERSECTION;
 	}
@@ -630,20 +806,36 @@ LineIntersector::computeCollinearIntersection(const Coordinate& p1,const Coordin
 		intPt[0]=q1;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		q1z = interpolateZ(q1, p1, p2);
-		if (!ISNAN(q1z)) { ztot+=q1z; hits++; }
-		if (!ISNAN(q1.z)) { ztot+=q1.z; hits++; }
-		if ( hits ) intPt[0].z = ztot/hits;
+		if (!ISNAN(q1z)) { ztot+=q1z; hitsz++; }
+		if (!ISNAN(q1.z)) { ztot+=q1.z; hitsz++; }
+		if ( hitsz ) intPt[0].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		q1m = interpolateM(q1, p1, p2);
+		if (!ISNAN(q1m)) { mtot+=q1m; hitsm++; }
+		if (!ISNAN(q1.m)) { mtot+=q1.m; hitsm++; }
+		if ( hitsm ) intPt[0].m = mtot/hitsm;
 #endif
 		intPt[1]=p1;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		p1z = interpolateZ(p1, q1, q2);
-		if (!ISNAN(p1z)) { ztot+=p1z; hits++; }
-		if (!ISNAN(p1.z)) { ztot+=p1.z; hits++; }
-		if ( hits ) intPt[1].z = ztot/hits;
+		if (!ISNAN(p1z)) { ztot+=p1z; hitsz++; }
+		if (!ISNAN(p1.z)) { ztot+=p1.z; hitsz++; }
+		if ( hitsz ) intPt[1].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		p1m = interpolateM(p1, q1, q2);
+		if (!ISNAN(p1m)) { mtot+=p1m; hitsm++; }
+		if (!ISNAN(p1.m)) { mtot+=p1.m; hitsm++; }
+		if ( hitsm ) intPt[1].m = mtot/hitsm;
 #endif
 #if GEOS_DEBUG
 		cerr<<" intPt[0]: "<<intPt[0].toString()<<endl;
@@ -658,20 +850,36 @@ LineIntersector::computeCollinearIntersection(const Coordinate& p1,const Coordin
 		intPt[0]=q1;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		q1z = interpolateZ(q1, p1, p2);
-		if (!ISNAN(q1z)) { ztot+=q1z; hits++; }
-		if (!ISNAN(q1.z)) { ztot+=q1.z; hits++; }
-		if ( hits ) intPt[0].z = ztot/hits;
+		if (!ISNAN(q1z)) { ztot+=q1z; hitsz++; }
+		if (!ISNAN(q1.z)) { ztot+=q1.z; hitsz++; }
+		if ( hitsz ) intPt[0].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		q1m = interpolateM(q1, p1, p2);
+		if (!ISNAN(q1m)) { mtot+=q1m; hitsm++; }
+		if (!ISNAN(q1.m)) { mtot+=q1.m; hitsm++; }
+		if ( hitsm ) intPt[0].m = mtot/hitsm;
 #endif
 		intPt[1]=p2;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		p2z = interpolateZ(p2, q1, q2);
-		if (!ISNAN(p2z)) { ztot+=p2z; hits++; }
-		if (!ISNAN(p2.z)) { ztot+=p2.z; hits++; }
-		if ( hits ) intPt[1].z = ztot/hits;
+		if (!ISNAN(p2z)) { ztot+=p2z; hitsz++; }
+		if (!ISNAN(p2.z)) { ztot+=p2.z; hitsz++; }
+		if ( hitsz ) intPt[1].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		p2m = interpolateM(p2, q1, q2);
+		if (!ISNAN(p2m)) { mtot+=p2m; hitsm++; }
+		if (!ISNAN(p2.m)) { mtot+=p2.m; hitsm++; }
+		if ( hitsm ) intPt[1].m = mtot/hitsm;
 #endif
 #if GEOS_DEBUG
 		cerr<<" intPt[0]: "<<intPt[0].toString()<<endl;
@@ -686,20 +894,36 @@ LineIntersector::computeCollinearIntersection(const Coordinate& p1,const Coordin
 		intPt[0]=q2;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		q2z = interpolateZ(q2, p1, p2);
-		if (!ISNAN(q2z)) { ztot+=q2z; hits++; }
-		if (!ISNAN(q2.z)) { ztot+=q2.z; hits++; }
-		if ( hits ) intPt[0].z = ztot/hits;
+		if (!ISNAN(q2z)) { ztot+=q2z; hitsz++; }
+		if (!ISNAN(q2.z)) { ztot+=q2.z; hitsz++; }
+		if ( hitsz ) intPt[0].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		q2m = interpolateM(q2, p1, p2);
+		if (!ISNAN(q2m)) { mtot+=q2m; hitsm++; }
+		if (!ISNAN(q2.m)) { mtot+=q2.m; hitsm++; }
+		if ( hitsm ) intPt[0].m = mtot/hitsm;
 #endif
 		intPt[1]=p1;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		p1z = interpolateZ(p1, q1, q2);
-		if (!ISNAN(p1z)) { ztot+=p1z; hits++; }
-		if (!ISNAN(p1.z)) { ztot+=p1.z; hits++; }
-		if ( hits ) intPt[1].z = ztot/hits;
+		if (!ISNAN(p1z)) { ztot+=p1z; hitsz++; }
+		if (!ISNAN(p1.z)) { ztot+=p1.z; hitsz++; }
+		if ( hitsz ) intPt[1].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		p1m = interpolateM(p1, q1, q2);
+		if (!ISNAN(p1m)) { mtot+=p1m; hitsm++; }
+		if (!ISNAN(p1.m)) { mtot+=p1.m; hitsm++; }
+		if ( hitsm ) intPt[1].m = mtot/hitsm;
 #endif
 #if GEOS_DEBUG
 		cerr<<" intPt[0]: "<<intPt[0].toString()<<endl;
@@ -714,20 +938,37 @@ LineIntersector::computeCollinearIntersection(const Coordinate& p1,const Coordin
 		intPt[0]=q2;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		q2z = interpolateZ(q2, p1, p2);
-		if (!ISNAN(q2z)) { ztot+=q2z; hits++; }
-		if (!ISNAN(q2.z)) { ztot+=q2.z; hits++; }
-		if ( hits ) intPt[0].z = ztot/hits;
+		if (!ISNAN(q2z)) { ztot+=q2z; hitsz++; }
+		if (!ISNAN(q2.z)) { ztot+=q2.z; hitsz++; }
+		if ( hitsz ) intPt[0].z = ztot/hitsz;
+#endif
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		q2m = interpolateM(q2, p1, p2);
+		if (!ISNAN(q2m)) { mtot+=q2m; hitsm++; }
+		if (!ISNAN(q2.m)) { mtot+=q2.m; hitsm++; }
+		if ( hitsm ) intPt[0].m = mtot/hitsm;
 #endif
 		intPt[1]=p2;
 #if COMPUTE_Z
 		ztot=0;
-		hits=0;
+		hitsz=0;
 		p2z = interpolateZ(p2, q1, q2);
-		if (!ISNAN(p2z)) { ztot+=p2z; hits++; }
-		if (!ISNAN(p2.z)) { ztot+=p2.z; hits++; }
-		if ( hits ) intPt[1].z = ztot/hits;
+		if (!ISNAN(p2z)) { ztot+=p2z; hitsz++; }
+		if (!ISNAN(p2.z)) { ztot+=p2.z; hitsz++; }
+		if ( hitsz ) intPt[1].z = ztot/hitsz;
+#endif
+
+#if COMPUTE_M
+		mtot=0;
+		hitsm=0;
+		p2m = interpolateM(p2, q1, q2);
+		if (!ISNAN(p2m)) { mtot+=p2m; hitsm++; }
+		if (!ISNAN(p2.m)) { mtot+=p2.m; hitsm++; }
+		if ( hitsm ) intPt[1].m = mtot/hitsm;
 #endif
 #if GEOS_DEBUG
 		cerr<<" intPt[0]: "<<intPt[0].toString()<<endl;
@@ -786,6 +1027,16 @@ LineIntersector::intersection(const Coordinate& p1,
 	if ( !ISNAN(zq)) { ztot += zq; zvals++; }
 	if ( zvals ) intPt.z = ztot/zvals;
 #endif // COMPUTE_Z
+
+#if COMPUTE_M
+	double mtot = 0;
+	double mvals = 0;
+	double mp = interpolateM(intPt, p1, p2);
+	double mq = interpolateM(intPt, q1, q2);
+	if ( !ISNAN(mp)) { mtot += mp; mvals++; }
+	if ( !ISNAN(mq)) { mtot += mq; mvals++; }
+	if ( mvals ) intPt.m = mtot/mvals;
+#endif // COMPUTE_M
 
 }
 
@@ -882,6 +1133,21 @@ LineIntersector::normalizeToEnvCentre(Coordinate &n00, Coordinate &n01,
 	n01.z -= normPt.z;
 	n10.z -= normPt.z;
 	n11.z -= normPt.z;
+#endif
+
+#if COMPUTE_M
+	double minM0 = n00.m < n01.m ? n00.m : n01.m;
+	double minM1 = n10.m < n11.m ? n10.m : n11.m;
+	double maxM0 = n00.m > n01.m ? n00.m : n01.m;
+	double maxM1 = n10.m > n11.m ? n10.m : n11.m;
+	double intMinM = minM0 > minM1 ? minM0 : minM1;
+	double intMaxM = maxM0 < maxM1 ? maxM0 : maxM1;
+	double intMidM = (intMinM + intMaxM) / 2.0;
+	normPt.m = intMidM;
+	n00.m -= normPt.m;
+	n01.m -= normPt.m;
+	n10.m -= normPt.m;
+	n11.m -= normPt.m;
 #endif
 }
 

--- a/src/geom/Coordinate.cpp
+++ b/src/geom/Coordinate.cpp
@@ -46,11 +46,14 @@ Coordinate::toString() const
 
 std::ostream& operator<< (std::ostream& os, const Coordinate& c)
 {
-	if ( ISNAN(c.z) )
+	os << c.x << " " << c.y;
+	if ( !ISNAN(c.z) )
 	{
-		os << c.x << " " << c.y;
-	} else {
-		os << c.x << " " << c.y << " " << c.z;
+		os << " " << c.z;
+	}
+	if ( !ISNAN(c.m) )
+	{
+		os << " m:" << c.m;
 	}
 	return os;
 }

--- a/src/geom/Coordinate.cpp
+++ b/src/geom/Coordinate.cpp
@@ -51,10 +51,12 @@ std::ostream& operator<< (std::ostream& os, const Coordinate& c)
 	{
 		os << " " << c.z;
 	}
+#ifdef GEOS_MVALUES
 	if ( !ISNAN(c.m) )
 	{
 		os << " m:" << c.m;
 	}
+#endif
 	return os;
 }
 

--- a/src/geom/CoordinateArraySequence.cpp
+++ b/src/geom/CoordinateArraySequence.cpp
@@ -30,16 +30,19 @@ using namespace std;
 namespace geos {
 namespace geom { // geos::geom
 
-CoordinateArraySequence::CoordinateArraySequence():
-	vect(new vector<Coordinate>()),
-	hasZ(1),
-	hasM(0)
+CoordinateArraySequence::CoordinateArraySequence()
+	: vect(new vector<Coordinate>())
+	, hasZ(1)
+#ifdef GEOS_MVALUES
+	, hasM(0)
+#endif
 {
 }
 
 CoordinateArraySequence::CoordinateArraySequence(size_t n, std::size_t dimension, bool dim3isM):
 	vect(new vector<Coordinate>(n))
 {
+#ifdef GEOS_MVALUES
 	if(dimension == 0) {
 		hasZ = hasM = -1;
 	}else if(dimension < 3){
@@ -50,11 +53,21 @@ CoordinateArraySequence::CoordinateArraySequence(size_t n, std::size_t dimension
 	}else /*if(dimension == 4)*/{
 		hasZ = hasM = 1;
 	}
+#else
+	if(dimension == 0) {
+		hasZ = -1;
+	}else if(dimension < 3){
+		hasZ = 0;
+	}else /*if(dimension == 3)*/{
+		hasZ = 1;
+	}
+#endif
 }
 
 CoordinateArraySequence::CoordinateArraySequence(vector<Coordinate> *coords, std::size_t dimension, bool dim3isM)
 		: vect(coords)
 {
+#ifdef GEOS_MVALUES
 	if(dimension == 0) {
 		hasZ = hasM = -1;
 	}else if(dimension < 3){
@@ -65,27 +78,38 @@ CoordinateArraySequence::CoordinateArraySequence(vector<Coordinate> *coords, std
 	}else /*if(dimension == 4)*/{
 		hasZ = hasM = 1;
 	}
+#else
+	if(dimension == 0) {
+		hasZ = -1;
+	}else if(dimension < 3){
+		hasZ = 0;
+	}else /*if(dimension == 3)*/{
+		hasZ = 1;
+	}
+#endif
 
 	if ( ! vect ) vect = new vector<Coordinate>();
 }
 
 CoordinateArraySequence::CoordinateArraySequence(
     const CoordinateArraySequence &c )
-	:
-	CoordinateSequence(c),
-	vect(new vector<Coordinate>(*(c.vect))),
-	hasZ(c.getHasZ()),
-	hasM(c.getHasM())
+	: CoordinateSequence(c)
+	, vect(new vector<Coordinate>(*(c.vect)))
+	, hasZ(c.getHasZ())
+#ifdef GEOS_MVALUES
+	, hasM(c.getHasM())
+#endif
 {
 }
 
 CoordinateArraySequence::CoordinateArraySequence(
     const CoordinateSequence &c )
-	:
-	CoordinateSequence(c),
-	vect(new vector<Coordinate>(c.size())),
-	hasZ(c.getHasZ()),
-	hasM(c.getHasM())
+	: CoordinateSequence(c)
+	, vect(new vector<Coordinate>(c.size()))
+	, hasZ(c.getHasZ())
+#ifdef GEOS_MVALUES
+	, hasM(c.getHasM())
+#endif
 {
   for (size_t i = 0, n = vect->size(); i < n; ++i) {
       (*vect)[i] = c.getAt(i);
@@ -123,6 +147,7 @@ CoordinateArraySequence::getHasZ() const
 	return hasZ;
 }
 
+#ifdef GEOS_MVALUES
 bool
 CoordinateArraySequence::getHasM() const
 {
@@ -135,6 +160,7 @@ CoordinateArraySequence::getHasM() const
 	}
 	return hasM;
 }
+#endif
 
 void
 CoordinateArraySequence::toVector(vector<Coordinate>& out) const
@@ -254,8 +280,10 @@ CoordinateArraySequence::getOrdinate(size_t index, size_t ordinateIndex) const
 			return (*vect)[index].y;
 		case CoordinateSequence::Z:
 			return (*vect)[index].z;
+#ifdef GEOS_MVALUES
 		case CoordinateSequence::M:
 			return (*vect)[index].m;
+#endif
 		default:
 			return DoubleNotANumber;
 	}
@@ -276,9 +304,11 @@ CoordinateArraySequence::setOrdinate(size_t index, size_t ordinateIndex,
 		case CoordinateSequence::Z:
 			(*vect)[index].z = value;
 			break;
+#ifdef GEOS_MVALUES
 		case CoordinateSequence::M:
-		(*vect)[index].m = value;
-		break;
+			(*vect)[index].m = value;
+			break;
+#endif
 		default:
 		{
 			std::stringstream ss;
@@ -297,7 +327,10 @@ CoordinateArraySequence::apply_rw(const CoordinateFilter *filter)
 		filter->filter_rw(&(*i));
 	}
 	// re-check (see http://trac.osgeo.org/geos/ticket/435)
-	hasZ = hasM = -1;
+	hasZ = -1;
+#ifdef GEOS_MVALUES
+	hasM = -1;
+#endif
 }
 
 void

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -147,6 +147,28 @@ GeometryCollection::getCoordinateDimension() const
 	return dimension;
 }
 
+bool
+GeometryCollection::getHasZ() const
+{
+	bool hasZ = false;
+	for (size_t i=0, n=geometries->size(); i<n; ++i)
+	{
+		hasZ|=(*geometries)[i]->getHasZ();
+	}
+	return hasZ;
+}
+
+bool
+GeometryCollection::getHasM() const
+{
+	bool hasM = false;
+	for (size_t i=0, n=geometries->size(); i<n; ++i)
+	{
+		hasM|=(*geometries)[i]->getHasZ();
+	}
+	return hasM;
+}
+
 size_t
 GeometryCollection::getNumGeometries() const
 {

--- a/src/geom/GeometryCollection.cpp
+++ b/src/geom/GeometryCollection.cpp
@@ -158,6 +158,7 @@ GeometryCollection::getHasZ() const
 	return hasZ;
 }
 
+#ifdef GEOS_MVALUES
 bool
 GeometryCollection::getHasM() const
 {
@@ -168,6 +169,7 @@ GeometryCollection::getHasM() const
 	}
 	return hasM;
 }
+#endif
 
 size_t
 GeometryCollection::getNumGeometries() const

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -249,11 +249,17 @@ GeometryFactory::createPoint(const Coordinate& coordinate) const
 		return createPoint();
 	} else {
 		bool hasZ = !ISNAN(coordinate.z);
+#ifdef GEOS_MVALUES
 		bool hasM = !ISNAN(coordinate.m);
 		std::size_t dim = 2 + hasZ + hasM;
 		bool dim3isM = hasM && !hasZ;
 		CoordinateSequence *cl = coordinateListFactory->create(
 					new vector<Coordinate>(1, coordinate), dim, dim3isM);
+#else
+		std::size_t dim = 2 + hasZ;
+		CoordinateSequence *cl = coordinateListFactory->create(
+					new vector<Coordinate>(1, coordinate), dim);
+#endif
 		//cl->setAt(coordinate, 0);
 		Point *ret = createPoint(cl);
 		return ret;

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -248,8 +248,12 @@ GeometryFactory::createPoint(const Coordinate& coordinate) const
 	if (coordinate.isNull()) {
 		return createPoint();
 	} else {
-		std::size_t dim = ISNAN(coordinate.z) ? 2 : 3;
-		CoordinateSequence *cl = coordinateListFactory->create(new vector<Coordinate>(1, coordinate), dim);
+		bool hasZ = !ISNAN(coordinate.z);
+		bool hasM = !ISNAN(coordinate.m);
+		std::size_t dim = 2 + hasZ + hasM;
+		bool dim3isM = hasM && !hasZ;
+		CoordinateSequence *cl = coordinateListFactory->create(
+					new vector<Coordinate>(1, coordinate), dim, dim3isM);
 		//cl->setAt(coordinate, 0);
 		Point *ret = createPoint(cl);
 		return ret;

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -147,11 +147,13 @@ LineString::getHasZ() const
 	return points->getHasZ();
 }
 
+#ifdef GEOS_MVALUES
 bool
 LineString::getHasM() const
 {
 	return points->getHasM();
 }
+#endif
 
 int
 LineString::getBoundaryDimension() const

--- a/src/geom/LineString.cpp
+++ b/src/geom/LineString.cpp
@@ -141,6 +141,18 @@ LineString::getCoordinateDimension() const
     return (int) points->getDimension();
 }
 
+bool
+LineString::getHasZ() const
+{
+	return points->getHasZ();
+}
+
+bool
+LineString::getHasM() const
+{
+	return points->getHasM();
+}
+
 int
 LineString::getBoundaryDimension() const
 {

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -108,11 +108,13 @@ Point::getHasZ() const
 	return coordinates->getHasZ();
 }
 
+#ifdef GEOS_MVALUES
 bool
 Point::getHasM() const
 {
 	return coordinates->getHasM();
 }
+#endif
 
 int
 Point::getBoundaryDimension() const

--- a/src/geom/Point.cpp
+++ b/src/geom/Point.cpp
@@ -102,6 +102,18 @@ Point::getCoordinateDimension() const
     return (int) coordinates->getDimension();
 }
 
+bool
+Point::getHasZ() const
+{
+	return coordinates->getHasZ();
+}
+
+bool
+Point::getHasM() const
+{
+	return coordinates->getHasM();
+}
+
 int
 Point::getBoundaryDimension() const
 {

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -163,6 +163,40 @@ Polygon::getCoordinateDimension() const
 	return dimension;
 }
 
+bool
+Polygon::getHasZ() const
+{
+	bool hasZ = false;
+
+	if( shell != NULL )
+		hasZ |= shell->getHasZ();
+
+	size_t nholes=holes->size();
+	for (size_t i=0; i<nholes; ++i)
+	{
+		hasZ |= (*holes)[i]->getHasZ();
+	}
+
+	return hasZ;
+}
+
+bool
+Polygon::getHasM() const
+{
+	bool hasM = false;
+
+	if( shell != NULL )
+		hasM |= shell->getHasM();
+
+	size_t nholes=holes->size();
+	for (size_t i=0; i<nholes; ++i)
+	{
+		hasM |= (*holes)[i]->getHasM();
+	}
+
+	return hasM;
+}
+
 int
 Polygon::getBoundaryDimension() const
 {

--- a/src/geom/Polygon.cpp
+++ b/src/geom/Polygon.cpp
@@ -180,6 +180,7 @@ Polygon::getHasZ() const
 	return hasZ;
 }
 
+#ifdef GEOS_MVALUES
 bool
 Polygon::getHasM() const
 {
@@ -196,6 +197,7 @@ Polygon::getHasM() const
 
 	return hasM;
 }
+#endif
 
 int
 Polygon::getBoundaryDimension() const

--- a/src/geomgraph/Node.cpp
+++ b/src/geomgraph/Node.cpp
@@ -40,6 +40,9 @@
 #ifndef COMPUTE_Z
 #define COMPUTE_Z 1
 #endif
+#ifndef COMPUTE_M
+#define COMPUTE_M 1
+#endif
 
 using namespace std;
 using namespace geos::geom;
@@ -72,6 +75,19 @@ Node::Node(const Coordinate& newCoord, EdgeEndStar* newEdges)
 		}
 	}
 #endif // COMPUTE_Z
+#if COMPUTE_M
+	mtot = 0;
+	addM(newCoord.m);
+	if ( edges )
+	{
+		EdgeEndStar::iterator endIt = edges->end();
+		for (EdgeEndStar::iterator it=edges->begin(); it!=endIt; ++it)
+		{
+			EdgeEnd *ee = *it;
+			addM(ee->getCoordinate().m);
+		}
+	}
+#endif // COMPUTE_M
 
 	testInvariant();
 }
@@ -157,6 +173,9 @@ Node::add(EdgeEnd *e)
 	e->setNode(this);
 #if COMPUTE_Z
 	addZ(e->getCoordinate().z);
+#endif
+#if COMPUTE_M
+	addM(e->getCoordinate().m);
 #endif
 	testInvariant();
 }
@@ -268,10 +287,46 @@ Node::addZ(double z)
 }
 
 /*public*/
+void
+Node::addM(double m)
+{
+#if GEOS_DEBUG
+	cerr<<"["<<this<<"] Node::addM("<<m<<")";
+#endif
+	if ( ISNAN(m) )
+	{
+#if GEOS_DEBUG
+		cerr<<" skipped"<<endl;
+#endif
+		return;
+	}
+	if ( find(mvals.begin(), mvals.end(), m) != mvals.end() )
+	{
+#if GEOS_DEBUG
+		cerr<<" already stored"<<endl;
+#endif
+		return;
+	}
+	mvals.push_back(m);
+	mtot+=m;
+	coord.m=mtot/mvals.size();
+#if GEOS_DEBUG
+	cerr<<" added "<<m<<": ["<<mtot<<"/"<<mvals.sime()<<"="<<coord.m<<"]"<<endl;
+#endif
+}
+
+/*public*/
 const vector<double>&
 Node::getZ() const
 {
 	return zvals;
+}
+
+/*public*/
+const vector<double>&
+Node::getM() const
+{
+	return mvals;
 }
 
 std::ostream& operator<< (std::ostream& os, const Node& node)

--- a/src/geomgraph/Node.cpp
+++ b/src/geomgraph/Node.cpp
@@ -40,8 +40,12 @@
 #ifndef COMPUTE_Z
 #define COMPUTE_Z 1
 #endif
-#ifndef COMPUTE_M
-#define COMPUTE_M 1
+#ifdef GEOS_MVALUES
+# ifndef COMPUTE_M
+#  define COMPUTE_M 1
+# endif
+#else
+# undef COMPUTE_M
 #endif
 
 using namespace std;
@@ -286,6 +290,7 @@ Node::addZ(double z)
 #endif
 }
 
+#ifdef GEOS_MVALUES
 /*public*/
 void
 Node::addM(double m)
@@ -314,6 +319,7 @@ Node::addM(double m)
 	cerr<<" added "<<m<<": ["<<mtot<<"/"<<mvals.sime()<<"="<<coord.m<<"]"<<endl;
 #endif
 }
+#endif
 
 /*public*/
 const vector<double>&
@@ -322,12 +328,14 @@ Node::getZ() const
 	return zvals;
 }
 
+#ifdef GEOS_MVALUES
 /*public*/
 const vector<double>&
 Node::getM() const
 {
 	return mvals;
 }
+#endif
 
 std::ostream& operator<< (std::ostream& os, const Node& node)
 {

--- a/src/geomgraph/NodeMap.cpp
+++ b/src/geomgraph/NodeMap.cpp
@@ -78,6 +78,7 @@ NodeMap::addNode(const Coordinate& coord)
                 cerr<<" already found ("<<node->getCoordinate().toString()<<") - adding Z"<<endl;
 #endif
                 node->addZ(coord.z);
+                node->addM(coord.m);
         }
         return node;
 }

--- a/src/geomgraph/NodeMap.cpp
+++ b/src/geomgraph/NodeMap.cpp
@@ -78,7 +78,9 @@ NodeMap::addNode(const Coordinate& coord)
                 cerr<<" already found ("<<node->getCoordinate().toString()<<") - adding Z"<<endl;
 #endif
                 node->addZ(coord.z);
+#ifdef GEOS_MVALUES
                 node->addM(coord.m);
+#endif
         }
         return node;
 }

--- a/src/io/WKBReader.cpp
+++ b/src/io/WKBReader.cpp
@@ -276,7 +276,11 @@ WKBReader::readGeometry()
 
 
 	// allocate space for ordValues 
+#ifdef GEOS_MVALUES
 	ordValues.resize(4);
+#else
+	ordValues.resize(3);
+#endif
 
 	Geometry *result;
 
@@ -316,11 +320,14 @@ Point *
 WKBReader::readPoint()
 {
 	readCoordinate();
+#ifdef GEOS_MVALUES
 	if(hasZ && hasM){
 		return factory.createPoint(Coordinate(ordValues[0], ordValues[1], ordValues[2], ordValues[3]));
 	}else if(hasM){
 		return factory.createPoint(Coordinate(ordValues[0], ordValues[1], DoubleNotANumber, ordValues[3]));
-	}else if(hasZ){
+	}else 
+#endif
+	if(hasZ){
 	  return factory.createPoint(Coordinate(ordValues[0], ordValues[1], ordValues[2]));
 	}else{
 	  return factory.createPoint(Coordinate(ordValues[0], ordValues[1]));
@@ -483,7 +490,11 @@ CoordinateSequence *
 WKBReader::readCoordinateSequence(int size)
 {
 	std::size_t dim = 2 + hasZ + hasM;
+#ifdef GEOS_MVALUES
 	bool dim3isM = hasM && !hasZ;
+#else
+	bool dim3isM = false;
+#endif
 	CoordinateSequence *seq = factory.getCoordinateSequenceFactory()->create(
 				size, dim, dim3isM);
 	for (int i=0; i<size; i++) {
@@ -492,8 +503,10 @@ WKBReader::readCoordinateSequence(int size)
 		seq->setOrdinate(i, 1, ordValues[1]);
 		if(hasZ)
 			seq->setOrdinate(i, 2, ordValues[2]);
+#ifdef GEOS_MVALUES
 		if(hasM)
 			seq->setOrdinate(i, 3, ordValues[3]);
+#endif
 	}
 	return seq;
 }
@@ -506,8 +519,10 @@ WKBReader::readCoordinate()
 	ordValues[1] = pm.makePrecise(dis.readDouble());
 	if(hasZ)
 		ordValues[2] = dis.readDouble();
+#ifdef GEOS_MVALUES
 	if(hasM)
 		ordValues[3] = dis.readDouble();
+#endif
 #if DEBUG_WKB_READER
 	cout<<"WKB coordinate: "<<ordValues[0]<<","<<ordValues[1]<<endl;
 #endif

--- a/src/io/WKBWriter.cpp
+++ b/src/io/WKBWriter.cpp
@@ -81,13 +81,18 @@ WKBWriter::writeHEX(const Geometry &g, ostream &os)
 void
 WKBWriter::write(const Geometry &g, ostream &os) 
 {
+#ifdef GEOS_MVALUES
 	outputZ = (defaultOutputDimension == 4 ||
 			   (defaultOutputDimension == 3 && (!defaultOutputPreferM || !g.getHasM()))
 			  ) && g.getHasZ();
-    outputM = (defaultOutputDimension == 4 ||
+	outputM = (defaultOutputDimension == 4 ||
 			   (defaultOutputDimension == 3 && defaultOutputPreferM) ||
 			   (defaultOutputDimension == 3 && !g.getHasZ())
 			  ) && g.getHasM();
+#else
+	outputZ = defaultOutputDimension == 3 && g.getHasZ();
+	outputM = false;
+#endif
 
 	outStream = &os;
 
@@ -301,6 +306,7 @@ WKBWriter::writeCoordinate(const CoordinateSequence &cs, int idx)
 			buf, byteOrder);
 		outStream->write(reinterpret_cast<char *>(buf), 8);
 	}
+#ifdef GEOS_MVALUES
 	if ( outputM )
 	{
 		ByteOrderValues::putDouble(
@@ -308,6 +314,7 @@ WKBWriter::writeCoordinate(const CoordinateSequence &cs, int idx)
 			buf, byteOrder);
 		outStream->write(reinterpret_cast<char *>(buf), 8);
 	}
+#endif
 }
 
 

--- a/src/io/WKTReader.cpp
+++ b/src/io/WKTReader.cpp
@@ -82,8 +82,13 @@ WKTReader::getCoordinates(StringTokenizer *tokenizer)
 	Coordinate coord;
 	getPreciseCoordinate(tokenizer, coord, hasZ, hasM);
 
+#ifdef GEOS_MVALUES
 	std::size_t dim = 2 + hasZ + hasM;
 	bool dim3isM = hasM && !hasZ;
+#else
+	std::size_t dim = 2 + hasZ;
+	bool dim3isM = false;
+#endif
 	CoordinateSequence *coordinates = \
 			geometryFactory->getCoordinateSequenceFactory()->create(
 				(size_t)0, dim, dim3isM);
@@ -112,12 +117,16 @@ WKTReader::getPreciseCoordinate(StringTokenizer *tokenizer,
 	coord.x=getNextNumber(tokenizer);
 	coord.y=getNextNumber(tokenizer);
 	coord.z=DoubleNotANumber;
+#ifdef GEOS_MVALUES
 	coord.m=DoubleNotANumber;
+#endif
 	if (isNumberNext(tokenizer)) {
 		if(hasZ)
-		coord.z=getNextNumber(tokenizer);
+			coord.z=getNextNumber(tokenizer);
+#ifdef GEOS_MVALUES
 		else if(hasM)
 			coord.m=getNextNumber(tokenizer);
+#endif
 		else {
 			// Old-style WKT, three values but no Z in type
 			hasZ = true;
@@ -125,9 +134,11 @@ WKTReader::getPreciseCoordinate(StringTokenizer *tokenizer,
 		}
 	}
 	if (isNumberNext(tokenizer)) {
+#ifdef GEOS_MVALUES
 		if(hasZ && hasM)
 			coord.m=getNextNumber(tokenizer);
 		else
+#endif
 			// Discard bogous value
 			getNextNumber(tokenizer);
 	}

--- a/src/io/WKTReader.cpp
+++ b/src/io/WKTReader.cpp
@@ -71,23 +71,27 @@ WKTReader::read(const string &wellKnownText)
 CoordinateSequence*
 WKTReader::getCoordinates(StringTokenizer *tokenizer)
 {
-	size_t dim;
-	string nextToken=getNextEmptyOrOpener(tokenizer);
+	bool hasZ = false;
+	bool hasM = false;
+	string nextToken=getNextDimensionalityOrOpener(tokenizer, hasZ, hasM);
 	if (nextToken=="EMPTY") {
 		return geometryFactory->getCoordinateSequenceFactory()->create();
 		//new CoordinateArraySequence(); 
 	}
 
 	Coordinate coord;
-	getPreciseCoordinate(tokenizer, coord, dim);
+	getPreciseCoordinate(tokenizer, coord, hasZ, hasM);
 
+	std::size_t dim = 2 + hasZ + hasM;
+	bool dim3isM = hasM && !hasZ;
 	CoordinateSequence *coordinates = \
-            geometryFactory->getCoordinateSequenceFactory()->create((size_t)0,dim);
+			geometryFactory->getCoordinateSequenceFactory()->create(
+				(size_t)0, dim, dim3isM);
 	coordinates->add(coord);
 	try {
 		nextToken=getNextCloserOrComma(tokenizer);
 		while (nextToken==",") {
-			getPreciseCoordinate(tokenizer, coord, dim );
+			getPreciseCoordinate(tokenizer, coord, hasZ, hasM );
 			coordinates->add(coord);
 			nextToken=getNextCloserOrComma(tokenizer);
 		}
@@ -102,21 +106,30 @@ WKTReader::getCoordinates(StringTokenizer *tokenizer)
 void
 WKTReader::getPreciseCoordinate(StringTokenizer *tokenizer, 
                                 Coordinate& coord,
-                                size_t &dim )
+                                bool& hasZ,
+                                bool hasM)
 {
 	coord.x=getNextNumber(tokenizer);
 	coord.y=getNextNumber(tokenizer);
+	coord.z=DoubleNotANumber;
+	coord.m=DoubleNotANumber;
 	if (isNumberNext(tokenizer)) {
+		if(hasZ)
 		coord.z=getNextNumber(tokenizer);
-		dim = 3;
-        
-        // If there is a fourth value (M) read and discard it.
-        if (isNumberNext(tokenizer)) 
-            getNextNumber(tokenizer);
-
-	} else {
-		coord.z=DoubleNotANumber;
-		dim = 2;
+		else if(hasM)
+			coord.m=getNextNumber(tokenizer);
+		else {
+			// Old-style WKT, three values but no Z in type
+			hasZ = true;
+			coord.z=getNextNumber(tokenizer);
+		}
+	}
+	if (isNumberNext(tokenizer)) {
+		if(hasZ && hasM)
+			coord.m=getNextNumber(tokenizer);
+		else
+			// Discard bogous value
+			getNextNumber(tokenizer);
 	}
 	precisionModel->makePrecise(coord);
 }
@@ -152,14 +165,19 @@ WKTReader::getNextNumber(StringTokenizer *tokenizer)
 }
 
 string
-WKTReader::getNextEmptyOrOpener(StringTokenizer *tokenizer)
+WKTReader::getNextDimensionalityOrOpener(StringTokenizer *tokenizer, bool& hasZ, bool& hasM)
 {
 	string nextWord=getNextWord(tokenizer);
 
     // Skip the Z, M or ZM of an SF1.2 3/4 dim coordinate. 
-    if (nextWord == "Z" || nextWord == "M" || nextWord == "ZM" )
+	if (nextWord == "Z" || nextWord == "M" || nextWord == "ZM" ) {
+		hasZ = (nextWord == "Z" || nextWord == "ZM");
+		hasM = (nextWord == "M" || nextWord == "ZM");
         nextWord = getNextWord(tokenizer);
-
+	} else {
+		hasZ = false;
+		hasM = false;
+	}
 	if (nextWord=="EMPTY" || nextWord=="(") {
 		return nextWord;
 	}
@@ -247,14 +265,15 @@ WKTReader::readGeometryTaggedText(StringTokenizer *tokenizer)
 Point*
 WKTReader::readPointText(StringTokenizer *tokenizer)
 {
-	size_t dim;
-	string nextToken=getNextEmptyOrOpener(tokenizer);
+	bool hasZ = false;
+	bool hasM = false;
+	string nextToken=getNextDimensionalityOrOpener(tokenizer, hasZ, hasM);
 	if (nextToken=="EMPTY") {
 		return geometryFactory->createPoint(Coordinate::getNull());
 	}
 
 	Coordinate coord;
-	getPreciseCoordinate(tokenizer, coord, dim);
+	getPreciseCoordinate(tokenizer, coord, hasZ, hasM);
 	getNextCloser(tokenizer);
 
 	return geometryFactory->createPoint(coord);
@@ -276,7 +295,9 @@ LinearRing* WKTReader::readLinearRingText(StringTokenizer *tokenizer) {
 MultiPoint*
 WKTReader::readMultiPointText(StringTokenizer *tokenizer)
 {
-	string nextToken=getNextEmptyOrOpener(tokenizer);
+	bool hasZ = false;
+	bool hasM = false;
+	string nextToken=getNextDimensionalityOrOpener(tokenizer, hasZ, hasM);
 	if (nextToken=="EMPTY") {
 		return geometryFactory->createMultiPoint();
 	}
@@ -285,8 +306,6 @@ WKTReader::readMultiPointText(StringTokenizer *tokenizer)
 
 	if ( tok == StringTokenizer::TT_NUMBER )
 	{
-		size_t dim;
-
 		// Try to parse deprecated form "MULTIPOINT(0 0, 1 1)"
 		const CoordinateSequenceFactory* csf = \
 			geometryFactory->getCoordinateSequenceFactory();
@@ -294,7 +313,7 @@ WKTReader::readMultiPointText(StringTokenizer *tokenizer)
 		try {
 			do {
 				Coordinate coord;
-				getPreciseCoordinate(tokenizer, coord, dim);
+				getPreciseCoordinate(tokenizer, coord, hasZ, hasM);
 				coords->add(coord);
 				nextToken=getNextCloserOrComma(tokenizer);
 			} while(nextToken == ",");
@@ -365,11 +384,14 @@ WKTReader::readMultiPointText(StringTokenizer *tokenizer)
 }
 
 Polygon*
-WKTReader::readPolygonText(StringTokenizer *tokenizer)
+WKTReader
+::readPolygonText(StringTokenizer *tokenizer)
 {
 	Polygon *poly=NULL;
 	LinearRing *shell=NULL;
-	string nextToken=getNextEmptyOrOpener(tokenizer);
+	bool hasZ = false;
+	bool hasM = false;
+	string nextToken=getNextDimensionalityOrOpener(tokenizer, hasZ, hasM);
 	if (nextToken=="EMPTY") {
 		return geometryFactory->createPolygon(NULL,NULL);
 	}
@@ -395,7 +417,9 @@ WKTReader::readPolygonText(StringTokenizer *tokenizer)
 }
 
 MultiLineString* WKTReader::readMultiLineStringText(StringTokenizer *tokenizer) {
-	string nextToken=getNextEmptyOrOpener(tokenizer);
+	bool hasZ = false;
+	bool hasM = false;
+	string nextToken=getNextDimensionalityOrOpener(tokenizer, hasZ, hasM);
 	if (nextToken=="EMPTY") {
 		return geometryFactory->createMultiLineString(NULL);
 	}
@@ -415,7 +439,9 @@ MultiLineString* WKTReader::readMultiLineStringText(StringTokenizer *tokenizer) 
 }
 
 MultiPolygon* WKTReader::readMultiPolygonText(StringTokenizer *tokenizer) {
-	string nextToken=getNextEmptyOrOpener(tokenizer);
+	bool hasZ = false;
+	bool hasM = false;
+	string nextToken=getNextDimensionalityOrOpener(tokenizer, hasZ, hasM);
 	if (nextToken=="EMPTY") {
 		return geometryFactory->createMultiPolygon(NULL);
 	}
@@ -435,7 +461,9 @@ MultiPolygon* WKTReader::readMultiPolygonText(StringTokenizer *tokenizer) {
 }
 
 GeometryCollection* WKTReader::readGeometryCollectionText(StringTokenizer *tokenizer) {
-	string nextToken=getNextEmptyOrOpener(tokenizer);
+	bool hasZ = false;
+	bool hasM = false;
+	string nextToken=getNextDimensionalityOrOpener(tokenizer, hasZ, hasM);
 	if (nextToken=="EMPTY") {
 		return geometryFactory->createGeometryCollection(NULL);
 	}

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -64,8 +64,13 @@ WKTWriter::WKTWriter():
 void
 WKTWriter::setOutputDimension(int dims, bool preferM)
 {
+#ifdef GEOS_MVALUES
 	if ( dims < 2 || dims > 4 )
 		throw util::IllegalArgumentException("WKT output dimension must be 2 or 3 or 4");
+#else
+	if ( dims < 2 || dims > 3 )
+		throw util::IllegalArgumentException("WKT output dimension must be 2 or 3");
+#endif
 	defaultOutputDimension = dims;
 	defaultOutputPreferM = preferM;
 }
@@ -182,6 +187,7 @@ void
 WKTWriter::appendGeometryTaggedText(const Geometry *geometry, int level,
 		Writer *writer)
 {
+#ifdef GEOS_MVALUES
   outputZ = (defaultOutputDimension == 4 ||
 			 (defaultOutputDimension == 3 && (!defaultOutputPreferM || !geometry->getHasM()))
 			) && geometry->getHasZ();
@@ -189,6 +195,10 @@ WKTWriter::appendGeometryTaggedText(const Geometry *geometry, int level,
 			 (defaultOutputDimension == 3 && defaultOutputPreferM) ||
 			 (defaultOutputDimension == 3 && !geometry->getHasZ())
 			) && geometry->getHasM();
+#else
+  outputZ = defaultOutputDimension == 3 && geometry->getHasZ();
+  outputM = false;
+#endif
 
   indent(level, writer);
   if ( const Point* point = dynamic_cast<const Point*>(geometry) )
@@ -399,6 +409,7 @@ WKTWriter::appendCoordinate(const Coordinate* coordinate,
 		else
 			writer->write(writeNumber(coordinate->z));
 	}
+#ifdef GEOS_MVALUES
 	if( outputM )
 	{
 		writer->write(" ");
@@ -407,6 +418,7 @@ WKTWriter::appendCoordinate(const Coordinate* coordinate,
 		else
 			writer->write(writeNumber(coordinate->m));
 	}
+#endif
 }
 
 /* protected */

--- a/src/io/WKTWriter.cpp
+++ b/src/io/WKTWriter.cpp
@@ -55,17 +55,19 @@ WKTWriter::WKTWriter():
 	trim(false),
 	level(0),
 	defaultOutputDimension(2),
+	defaultOutputPreferM(false),
 	old3D(false)
 {
 }
 
 /* public */
 void
-WKTWriter::setOutputDimension(int dims)
+WKTWriter::setOutputDimension(int dims, bool preferM)
 {
-	if ( dims < 2 || dims > 3 )
-		throw util::IllegalArgumentException("WKT output dimension must be 2 or 3");
+	if ( dims < 2 || dims > 4 )
+		throw util::IllegalArgumentException("WKT output dimension must be 2 or 3 or 4");
 	defaultOutputDimension = dims;
+	defaultOutputPreferM = preferM;
 }
 
 WKTWriter::~WKTWriter() {}
@@ -180,8 +182,13 @@ void
 WKTWriter::appendGeometryTaggedText(const Geometry *geometry, int level,
 		Writer *writer)
 {
-  outputDimension = (std::min)( defaultOutputDimension,
-                         geometry->getCoordinateDimension() );
+  outputZ = (defaultOutputDimension == 4 ||
+			 (defaultOutputDimension == 3 && (!defaultOutputPreferM || !geometry->getHasM()))
+			) && geometry->getHasZ();
+  outputM = (defaultOutputDimension == 4 ||
+			 (defaultOutputDimension == 3 && defaultOutputPreferM) ||
+			 (defaultOutputDimension == 3 && !geometry->getHasZ())
+			) && geometry->getHasM();
 
   indent(level, writer);
   if ( const Point* point = dynamic_cast<const Point*>(geometry) )
@@ -235,8 +242,15 @@ WKTWriter::appendPointTaggedText(const Coordinate* coordinate, int level,
 		Writer *writer)
 {
 	writer->write("POINT ");
-    if( outputDimension == 3 && !old3D && coordinate != NULL )
-        writer->write( "Z " );
+	if( coordinate != NULL && !old3D ) {
+		if(outputZ && outputM) {
+			writer->write("ZM ");
+		} else if(outputZ) {
+			writer->write("Z ");
+		} else if(outputM) {
+			writer->write("M ");
+		}
+	}
 
 	appendPointText(coordinate, level, writer);
 }
@@ -246,8 +260,15 @@ WKTWriter::appendLineStringTaggedText(const LineString *lineString, int level,
 		Writer *writer)
 {
 	writer->write("LINESTRING ");
-    if( outputDimension == 3 && !old3D && !lineString->isEmpty() )
-        writer->write( "Z " );
+	if( !lineString->isEmpty() && !old3D ) {
+		if(outputZ && outputM) {
+			writer->write("ZM ");
+		} else if(outputZ) {
+			writer->write("Z ");
+		} else if(outputM) {
+			writer->write("M ");
+		}
+	}
 
 	appendLineStringText(lineString, level, false, writer);
 }
@@ -261,43 +282,91 @@ WKTWriter::appendLineStringTaggedText(const LineString *lineString, int level,
  */
 void WKTWriter::appendLinearRingTaggedText(const LinearRing* linearRing, int level, Writer *writer) {
 	writer->write("LINEARRING ");
-    if( outputDimension == 3 && !old3D && !linearRing->isEmpty() )
-        writer->write( "Z " );
+	if( !linearRing->isEmpty() && !old3D ) {
+		if(outputZ && outputM) {
+			writer->write("ZM");
+		} else if(outputZ) {
+			writer->write("Z");
+		} else if(outputM) {
+			writer->write("M");
+		}
+	}
+
 	appendLineStringText((LineString*)linearRing, level, false, writer);
 }
 
 void WKTWriter::appendPolygonTaggedText(const Polygon *polygon, int level, Writer *writer) {
 	writer->write("POLYGON ");
-    if( outputDimension == 3 && !old3D && !polygon->isEmpty())
-        writer->write( "Z " );
+	if( !polygon->isEmpty() && !old3D ) {
+		if(outputZ && outputM) {
+			writer->write("ZM");
+		} else if(outputZ) {
+			writer->write("Z");
+		} else if(outputM) {
+			writer->write("M");
+		}
+	}
+
 	appendPolygonText(polygon, level, false, writer);
 }
 
 void WKTWriter::appendMultiPointTaggedText(const MultiPoint *multipoint, int level, Writer *writer) {
 	writer->write("MULTIPOINT ");
-    if( outputDimension == 3 && !old3D && !multipoint->isEmpty() )
-        writer->write( "Z " );
+	if( !multipoint->isEmpty() && !old3D ) {
+		if(outputZ && outputM) {
+			writer->write("ZM");
+		} else if(outputZ) {
+			writer->write("Z");
+		} else if(outputM) {
+			writer->write("M");
+		}
+	}
+
 	appendMultiPointText(multipoint, level, writer);
 }
 
 void WKTWriter::appendMultiLineStringTaggedText(const MultiLineString *multiLineString, int level,Writer *writer) {
 	writer->write("MULTILINESTRING ");
-    if( outputDimension == 3 && !old3D && !multiLineString->isEmpty() )
-        writer->write( "Z " );
+	if( !multiLineString->isEmpty() && !old3D ) {
+		if(outputZ && outputM) {
+			writer->write("ZM");
+		} else if(outputZ) {
+			writer->write("Z");
+		} else if(outputM) {
+			writer->write("M");
+		}
+	}
+
 	appendMultiLineStringText(multiLineString, level, false, writer);
 }
 
 void WKTWriter::appendMultiPolygonTaggedText(const MultiPolygon *multiPolygon, int level, Writer *writer) {
 	writer->write("MULTIPOLYGON ");
-    if( outputDimension == 3 && !old3D && !multiPolygon->isEmpty() )
-        writer->write( "Z " );
+	if( !multiPolygon->isEmpty() && !old3D ) {
+		if(outputZ && outputM) {
+			writer->write("ZM");
+		} else if(outputZ) {
+			writer->write("Z");
+		} else if(outputM) {
+			writer->write("M");
+		}
+	}
+
 	appendMultiPolygonText(multiPolygon, level, writer);
 }
 
 void WKTWriter::appendGeometryCollectionTaggedText(const GeometryCollection *geometryCollection, int level,Writer *writer) {
 	writer->write("GEOMETRYCOLLECTION ");
-    if( outputDimension == 3 && !old3D && !geometryCollection->isEmpty() )
-        writer->write( "Z " );
+	if( !geometryCollection->isEmpty() && !old3D ) {
+		if(outputZ && outputM) {
+			writer->write("ZM");
+		} else if(outputZ) {
+			writer->write("Z");
+		} else if(outputM) {
+			writer->write("M");
+		}
+	}
+
 	appendGeometryCollectionText(geometryCollection, level, writer);
 }
 
@@ -322,13 +391,21 @@ WKTWriter::appendCoordinate(const Coordinate* coordinate,
 	writer->write(writeNumber(coordinate->x));
 	writer->write(" ");
 	writer->write(writeNumber(coordinate->y));
-	if( outputDimension == 3 )
+	if( outputZ )
 	{
 		writer->write(" ");
 		if( ISNAN(coordinate->z) )
 			writer->write(writeNumber(0.0));
 		else
 			writer->write(writeNumber(coordinate->z));
+	}
+	if( outputM )
+	{
+		writer->write(" ");
+		if( ISNAN(coordinate->m) )
+			writer->write(writeNumber(0.0));
+		else
+			writer->write(writeNumber(coordinate->m));
 	}
 }
 

--- a/src/linearref/LinearLocation.cpp
+++ b/src/linearref/LinearLocation.cpp
@@ -52,8 +52,12 @@ LinearLocation::pointAlongSegmentByFraction(const Coordinate& p0, const Coordina
 	double y = (p1.y - p0.y) * frac + p0.y;
 	// interpolate Z value. If either input Z is NaN, result z will be NaN as well.
 	double z = (p1.z - p0.z) * frac + p0.z;
+#ifdef GEOS_MVALUES
 	double m = (p1.m - p0.m) * frac + p0.m;
 	return Coordinate(x, y, z, m);
+#else
+	return Coordinate(x, y, z);
+#endif
 }
 
 /* public */

--- a/src/linearref/LinearLocation.cpp
+++ b/src/linearref/LinearLocation.cpp
@@ -52,7 +52,8 @@ LinearLocation::pointAlongSegmentByFraction(const Coordinate& p0, const Coordina
 	double y = (p1.y - p0.y) * frac + p0.y;
 	// interpolate Z value. If either input Z is NaN, result z will be NaN as well.
 	double z = (p1.z - p0.z) * frac + p0.z;
-	return Coordinate(x, y, z);
+	double m = (p1.m - p0.m) * frac + p0.m;
+	return Coordinate(x, y, z, m);
 }
 
 /* public */

--- a/src/operation/overlay/LineBuilder.cpp
+++ b/src/operation/overlay/LineBuilder.cpp
@@ -36,7 +36,11 @@
 #define GEOS_DEBUG 0
 #endif
 #define COMPUTE_Z 1
-#define COMPUTE_M 1
+#ifdef GEOS_MVALUES
+# define COMPUTE_M 1
+#else
+# undef COMPUTE_M
+#endif
 
 using namespace std;
 using namespace geos::algorithm;
@@ -291,7 +295,7 @@ LineBuilder::propagateZ(CoordinateSequence *cs)
 }
 
 
-
+#ifdef GEOS_MVALUES
 /*
  * If the given CoordinateSequence has mixed m and m-less vertexes
  * set M for all vertexes missing it.
@@ -376,7 +380,7 @@ LineBuilder::propagateM(CoordinateSequence *cs)
 	}
 
 }
-
+#endif
 
 
 void

--- a/src/operation/overlay/OverlayOp.cpp
+++ b/src/operation/overlay/OverlayOp.cpp
@@ -57,7 +57,11 @@
 #endif
 
 #define COMPUTE_Z 1
-#define COMPUTE_M 1
+#ifdef GEOS_MVALUES
+# define COMPUTE_M 1
+#else
+# undef COMPUTE_M
+#endif
 #define USE_ELEVATION_MATRIX 1
 #define USE_INPUT_AVGZ 0
 #define USE_INPUT_AVGM 1
@@ -521,6 +525,7 @@ OverlayOp::getAverageZ(int targetIndex)
 	return avgz[targetIndex];
 }
 
+#ifdef GEOS_MVALUES
 /*static private*/
 double
 OverlayOp::getAverageM(const Polygon *poly)
@@ -561,6 +566,7 @@ OverlayOp::getAverageM(int targetIndex)
 	avgmcomputed[targetIndex] = true;
 	return avgm[targetIndex];
 }
+#endif
 
 /*private*/
 int
@@ -613,6 +619,7 @@ OverlayOp::mergeZ(Node *n, const LineString *line) const
 	return 0;
 }
 
+#ifdef GEOS_MVALUES
 /*private*/
 int
 OverlayOp::mergeM(Node *n, const Polygon *poly) const
@@ -663,6 +670,7 @@ OverlayOp::mergeM(Node *n, const LineString *line) const
 	}
 	return 0;
 }
+#endif
 
 /*private*/
 void

--- a/src/triangulate/quadedge/Vertex.cpp
+++ b/src/triangulate/quadedge/Vertex.cpp
@@ -38,6 +38,10 @@ Vertex::Vertex(double _x, double _y, double _z): p( _x, _y, _z)
 {
 }
 
+Vertex::Vertex(double _x, double _y, double _z, double _m): p( _x, _y, _z, _m)
+{
+}
+
 Vertex::Vertex(const Coordinate &_p) : p(_p)
 {
 }
@@ -121,7 +125,8 @@ std::auto_ptr<Vertex> Vertex::midPoint(const Vertex &a)
 	double xm = (p.x + a.getX()) / 2.0;
 	double ym = (p.y + a.getY()) / 2.0;
 	double zm = (p.z + a.getZ()) / 2.0;
-	return std::auto_ptr<Vertex>(new Vertex(xm, ym, zm));
+	double mm = (p.m + a.getM()) / 2.0;
+	return std::auto_ptr<Vertex>(new Vertex(xm, ym, zm, mm));
 }
 
 std::auto_ptr<Vertex> Vertex::circleCenter(const Vertex &b, const Vertex &c) const
@@ -188,6 +193,52 @@ double Vertex::interpolateZ(const Coordinate &p, const Coordinate &p0,
 	double dz = p1.z - p0.z;
 	double pz = p0.z + dz * (ptLen / segLen);
 	return pz;
+}
+
+double Vertex::interpolateMValue(const Vertex &v0, const Vertex &v1,
+		const Vertex &v2) const
+{
+	double x0 = v0.getX();
+	double y0 = v0.getY();
+	double a = v1.getX() - x0;
+	double b = v2.getX() - x0;
+	double c = v1.getY() - y0;
+	double d = v2.getY() - y0;
+	double det = a * d - b * c;
+	double dx = this->getX() - x0;
+	double dy = this->getY() - y0;
+	double t = (d * dx - b * dy) / det;
+	double u = (-c * dx + a * dy) / det;
+	double m = v0.getM() + t * (v1.getM() - v0.getM()) + u * (v2.getM() - v0.getM());
+	return m;
+}
+
+double Vertex::interpolateM(const Coordinate &p, const Coordinate &v0,
+		const Coordinate &v1, const Coordinate &v2)
+{
+	double x0 = v0.x;
+	double y0 = v0.y;
+	double a = v1.x - x0;
+	double b = v2.x - x0;
+	double c = v1.y - y0;
+	double d = v2.y - y0;
+	double det = a * d - b * c;
+	double dx = p.x - x0;
+	double dy = p.y - y0;
+	double t = (d * dx - b * dy) / det;
+	double u = (-c * dx + a * dy) / det;
+	double m = v0.m + t * (v1.m - v0.m) + u * (v2.m - v0.m);
+	return m;
+}
+
+double Vertex::interpolateM(const Coordinate &p, const Coordinate &p0,
+		const Coordinate &p1)
+{
+	double segLen = p0.distance(p1);
+	double ptLen = p.distance(p0);
+	double dm = p1.m - p0.m;
+	double pm = p0.m + dm * (ptLen / segLen);
+	return pm;
 }
 
 } //namespace geos.triangulate.quadedge

--- a/src/triangulate/quadedge/Vertex.cpp
+++ b/src/triangulate/quadedge/Vertex.cpp
@@ -38,9 +38,11 @@ Vertex::Vertex(double _x, double _y, double _z): p( _x, _y, _z)
 {
 }
 
+#ifdef GEOS_MVALUES
 Vertex::Vertex(double _x, double _y, double _z, double _m): p( _x, _y, _z, _m)
 {
 }
+#endif
 
 Vertex::Vertex(const Coordinate &_p) : p(_p)
 {
@@ -125,8 +127,12 @@ std::auto_ptr<Vertex> Vertex::midPoint(const Vertex &a)
 	double xm = (p.x + a.getX()) / 2.0;
 	double ym = (p.y + a.getY()) / 2.0;
 	double zm = (p.z + a.getZ()) / 2.0;
+#ifdef GEOS_MVALUES
 	double mm = (p.m + a.getM()) / 2.0;
 	return std::auto_ptr<Vertex>(new Vertex(xm, ym, zm, mm));
+#else
+	return std::auto_ptr<Vertex>(new Vertex(xm, ym, zm));
+#endif
 }
 
 std::auto_ptr<Vertex> Vertex::circleCenter(const Vertex &b, const Vertex &c) const
@@ -195,6 +201,7 @@ double Vertex::interpolateZ(const Coordinate &p, const Coordinate &p0,
 	return pz;
 }
 
+#ifdef GEOS_MVALUES
 double Vertex::interpolateMValue(const Vertex &v0, const Vertex &v1,
 		const Vertex &v2) const
 {
@@ -240,6 +247,7 @@ double Vertex::interpolateM(const Coordinate &p, const Coordinate &p0,
 	double pm = p0.m + dm * (ptLen / segLen);
 	return pm;
 }
+#endif
 
 } //namespace geos.triangulate.quadedge
 } //namespace geos.triangulate

--- a/tests/unit/geom/CoordinateArraySequenceTest.cpp
+++ b/tests/unit/geom/CoordinateArraySequenceTest.cpp
@@ -34,10 +34,12 @@ namespace tut
               if ( ISNAN(c->z) ) c->z = 0.0;
             }
             else c->z = DoubleNotANumber;
+#ifdef GEOS_MVALUES
             if ( isM ) {
               if ( ISNAN(c->m) ) c->m = 0.0;
             }
             else c->m = DoubleNotANumber;
+#endif
           }
         };
     };
@@ -195,8 +197,13 @@ namespace tut
 
 		// Create non-empty sequence
 		std::vector<Coordinate>* col = new std::vector<Coordinate>();
+#ifdef GEOS_MVALUES
 		col->push_back(Coordinate(1, 2, 3, 4));
 		col->push_back(Coordinate(5, 10, 15, 20));
+#else
+		col->push_back(Coordinate(1, 2, 3));
+		col->push_back(Coordinate(5, 10, 15));
+#endif
 		
 		const size_t size = 2;
 		geos::geom::CoordinateArraySequence sequence(col);
@@ -209,11 +216,15 @@ namespace tut
 		ensure_equals( sequence.getAt(0).x, 1 );
 		ensure_equals( sequence.getAt(0).y, 2 );
 		ensure_equals( sequence.getAt(0).z, 3 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(0).m, 4 );
+#endif
 		ensure_equals( sequence.getAt(1).x, 5 );
 		ensure_equals( sequence.getAt(1).y, 10 );
 		ensure_equals( sequence.getAt(1).z, 15 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(1).m, 20 );
+#endif
 
 		// Second version of getAt()
 		Coordinate buf;
@@ -222,13 +233,17 @@ namespace tut
 		ensure_equals( buf.x, 1 );
 		ensure_equals( buf.y, 2 );
 		ensure_equals( buf.z, 3 );
+#ifdef GEOS_MVALUES
 		ensure_equals( buf.m, 4 );
+#endif
 		
 		sequence.getAt(1, buf);
 		ensure_equals( buf.x, 5 );
 		ensure_equals( buf.y, 10 );
 		ensure_equals( buf.z, 15 );
+#ifdef GEOS_MVALUES
 		ensure_equals( buf.m, 20 );
+#endif
 	}
 
     // Test of add()
@@ -246,7 +261,11 @@ namespace tut
 		ensure_equals( sequence.size(), size );
 
 		// Add coordinates
+#ifdef GEOS_MVALUES
 		Coordinate tmp(1, 2, 3, 4);
+#else
+		Coordinate tmp(1, 2, 3);
+#endif
 		sequence.add(tmp); // insert copy of tmp
 		const size_t sizeOne = 1;
 
@@ -256,7 +275,9 @@ namespace tut
 		tmp.x = 5;
 		tmp.y = 10;
 		tmp.z = 15;
+#ifdef GEOS_MVALUES
 		tmp.m = 20;
+#endif
 		sequence.add(tmp); // insert copy of tmp
 		const size_t sizeTwo = 2;
 		
@@ -271,10 +292,14 @@ namespace tut
 		ensure_equals( sequence.getAt(0).x, 1 );
 		ensure_equals( sequence.getAt(0).y, 2 );
 		ensure_equals( sequence.getAt(0).z, 3 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(0).m, 4 );
+#endif
 		ensure_equals( sequence.getAt(1).x, 5 );
 		ensure_equals( sequence.getAt(1).y, 10 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(1).m, 20 );
+#endif
 	}
 
     // Test of setAt()
@@ -293,18 +318,28 @@ namespace tut
 		ensure( sequence.hasRepeatedPoints() );
 
 		// Set new values to first coordinate
+#ifdef GEOS_MVALUES
 		Coordinate first(1, 2, 3, 4);
+#else
+		Coordinate first(1, 2, 3);
+#endif
 		sequence.setAt(first, 0);
 
 		ensure_equals( sequence.size(), size );
 		ensure_equals( sequence.getAt(0).x, 1 );
 		ensure_equals( sequence.getAt(0).y, 2 );
 		ensure_equals( sequence.getAt(0).z, 3 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(0).m, 4 );
+#endif
 
 
 		// Set new values to second coordinate 
+#ifdef GEOS_MVALUES
 		Coordinate second(5, 10, 15, 20);
+#else
+		Coordinate second(5, 10, 15);
+#endif
 		sequence.setAt(second, 1);
 
 		ensure_equals( sequence.size(), size );
@@ -312,7 +347,9 @@ namespace tut
 		ensure_equals( sequence.getAt(1).x, 5 );
 		ensure_equals( sequence.getAt(1).y, 10 );
 		ensure_equals( sequence.getAt(1).z, 15 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(1).m, 20 );
+#endif
 
 		ensure( !sequence.hasRepeatedPoints() );
 	}
@@ -380,9 +417,15 @@ namespace tut
 		// Create collection of points
 		const std::vector<Coordinate>::size_type sizeCol = 3;
 		std::vector<Coordinate> col;
+#ifdef GEOS_MVALUES
 		col.push_back(Coordinate(1, 2, 3, 4));
 		col.push_back(Coordinate(5, 10, 15, 20));
 		col.push_back(Coordinate(9, 18, 27, 36));
+#else
+		col.push_back(Coordinate(1, 2, 3));
+		col.push_back(Coordinate(5, 10, 15));
+		col.push_back(Coordinate(9, 18, 27));
+#endif
 
 		ensure( "std::vector bug assumed!", !col.empty() );
 		ensure_equals( "std::vector bug assumed!", col.size(), sizeCol );
@@ -398,17 +441,23 @@ namespace tut
 		ensure_equals( sequence.getAt(0).x, 1 );
 		ensure_equals( sequence.getAt(0).y, 2 );
 		ensure_equals( sequence.getAt(0).z, 3 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(0).m, 4 );
+#endif
 
 		ensure_equals( sequence.getAt(1).x, 5 );
 		ensure_equals( sequence.getAt(1).y, 10 );
 		ensure_equals( sequence.getAt(1).z, 15 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(1).m, 20 );
+#endif
 
 		ensure_equals( sequence.getAt(2).x, 9 );
 		ensure_equals( sequence.getAt(2).y, 18 );
 		ensure_equals( sequence.getAt(2).z, 27 );
+#ifdef GEOS_MVALUES
 		ensure_equals( sequence.getAt(2).m, 36 );
+#endif
 	}
 
 	// Test of removeRepeatedPoints
@@ -495,7 +544,11 @@ namespace tut
 		using geos::geom::CoordinateArraySequence;
 		using geos::geom::CoordinateSequence;
 
+#ifdef GEOS_MVALUES
 		Coordinate c1(1, 2, 3, 4);
+#else
+		Coordinate c1(1, 2, 3);
+#endif
 
 		CoordinateArraySequence sequence1;
 
@@ -512,8 +565,10 @@ namespace tut
 		sequence1.setOrdinate(0, CoordinateSequence::Z, 7);
 		ensure_equals( sequence1[0].z, 7 );
 
+#ifdef GEOS_MVALUES
 		sequence1.setOrdinate(0, CoordinateSequence::M, 8);
 		ensure_equals( sequence1[0].m, 8 );
+#endif
 
 	}
 
@@ -526,7 +581,11 @@ namespace tut
 		using geos::geom::CoordinateArraySequence;
 		using geos::geom::CoordinateSequence;
 
+#ifdef GEOS_MVALUES
 		Coordinate c1(1, 2, 3, 4);
+#else
+		Coordinate c1(1, 2, 3);
+#endif
 
 		CoordinateArraySequence sequence1;
 
@@ -534,7 +593,7 @@ namespace tut
 
 		ensure_equals( sequence1[0], c1 );
 
-		// Order: Y, X, Z, M
+		// Order: Y, X, Z, (M)
 
 		sequence1.setOrdinate(0, CoordinateSequence::Y, 6);
 		ensure_equals( sequence1[0].y, 6 );
@@ -545,8 +604,10 @@ namespace tut
 		sequence1.setOrdinate(0, CoordinateSequence::Z, 7);
 		ensure_equals( sequence1[0].z, 7 );
 
+#ifdef GEOS_MVALUES
 		sequence1.setOrdinate(0, CoordinateSequence::M, 8);
 		ensure_equals( sequence1[0].m, 8 );
+#endif
 
 	}
 
@@ -571,28 +632,36 @@ namespace tut
 		seq.setOrdinate(0, CoordinateSequence::Y,  5); ensure_equals( seq[0].y, 5 );
 		seq.setOrdinate(0, CoordinateSequence::Z,  6); ensure_equals( seq[0].z, 6 );
 		seq.setOrdinate(0, CoordinateSequence::X,  4); ensure_equals( seq[0].x, 4 );
+#ifdef GEOS_MVALUES
 		seq.setOrdinate(0, CoordinateSequence::M,  7); ensure_equals( seq[0].m, 7 );
+#endif
 
 		// Index: 1 - Order: Z, X, Y, M
 
 		seq.setOrdinate(1, CoordinateSequence::Z,  9); ensure_equals( seq[1].z, 9 );
 		seq.setOrdinate(1, CoordinateSequence::X,  8); ensure_equals( seq[1].x, 8 );
 		seq.setOrdinate(1, CoordinateSequence::Y,  7); ensure_equals( seq[1].y, 7 );
+#ifdef GEOS_MVALUES
 		seq.setOrdinate(1, CoordinateSequence::M,  10); ensure_equals( seq[1].m, 10 );
+#endif
 
 		// Index: 2 - Order: X, Y, Z, M
 
 		seq.setOrdinate(2, CoordinateSequence::X,  34); ensure_equals( seq[2].x, 34 );
 		seq.setOrdinate(2, CoordinateSequence::Y,  -45); ensure_equals( seq[2].y, -45 );
 		seq.setOrdinate(2, CoordinateSequence::Z,  152); ensure_equals( seq[2].z, 152 );
+#ifdef GEOS_MVALUES
 		seq.setOrdinate(2, CoordinateSequence::M,  -163); ensure_equals( seq[2].m, -163 );
+#endif
 
 		// Index: 3 - Order: Y, Z, X, M
 
 		seq.setOrdinate(3, CoordinateSequence::Y,  63); ensure_equals( seq[3].y, 63 );
 		seq.setOrdinate(3, CoordinateSequence::Z,  13); ensure_equals( seq[3].z, 13 );
 		seq.setOrdinate(3, CoordinateSequence::X,  -65); ensure_equals( seq[3].x, -65 );
+#ifdef GEOS_MVALUES
 		seq.setOrdinate(3, CoordinateSequence::M,  -13); ensure_equals( seq[3].m, -13 );
+#endif
 
 	}
 

--- a/tests/unit/geom/CoordinateArraySequenceTest.cpp
+++ b/tests/unit/geom/CoordinateArraySequenceTest.cpp
@@ -27,12 +27,17 @@ namespace tut
         struct Filter : public geos::geom::CoordinateFilter
         {
           bool is3d;
-          Filter() : is3d(false) {}
+          bool isM;
+          Filter() : is3d(false), isM(false) {}
           void filter_rw(geos::geom::Coordinate* c) const {
             if ( is3d ) {
               if ( ISNAN(c->z) ) c->z = 0.0;
             }
             else c->z = DoubleNotANumber;
+            if ( isM ) {
+              if ( ISNAN(c->m) ) c->m = 0.0;
+            }
+            else c->m = DoubleNotANumber;
           }
         };
     };
@@ -190,8 +195,8 @@ namespace tut
 
 		// Create non-empty sequence
 		std::vector<Coordinate>* col = new std::vector<Coordinate>();
-		col->push_back(Coordinate(1, 2, 3));
-		col->push_back(Coordinate(5, 10, 15));
+		col->push_back(Coordinate(1, 2, 3, 4));
+		col->push_back(Coordinate(5, 10, 15, 20));
 		
 		const size_t size = 2;
 		geos::geom::CoordinateArraySequence sequence(col);
@@ -204,9 +209,11 @@ namespace tut
 		ensure_equals( sequence.getAt(0).x, 1 );
 		ensure_equals( sequence.getAt(0).y, 2 );
 		ensure_equals( sequence.getAt(0).z, 3 );
+		ensure_equals( sequence.getAt(0).m, 4 );
 		ensure_equals( sequence.getAt(1).x, 5 );
 		ensure_equals( sequence.getAt(1).y, 10 );
 		ensure_equals( sequence.getAt(1).z, 15 );
+		ensure_equals( sequence.getAt(1).m, 20 );
 
 		// Second version of getAt()
 		Coordinate buf;
@@ -215,11 +222,13 @@ namespace tut
 		ensure_equals( buf.x, 1 );
 		ensure_equals( buf.y, 2 );
 		ensure_equals( buf.z, 3 );
+		ensure_equals( buf.m, 4 );
 		
 		sequence.getAt(1, buf);
 		ensure_equals( buf.x, 5 );
 		ensure_equals( buf.y, 10 );
 		ensure_equals( buf.z, 15 );
+		ensure_equals( buf.m, 20 );
 	}
 
     // Test of add()
@@ -237,7 +246,7 @@ namespace tut
 		ensure_equals( sequence.size(), size );
 
 		// Add coordinates
-		Coordinate tmp(1, 2, 3);		
+		Coordinate tmp(1, 2, 3, 4);
 		sequence.add(tmp); // insert copy of tmp
 		const size_t sizeOne = 1;
 
@@ -247,6 +256,7 @@ namespace tut
 		tmp.x = 5;
 		tmp.y = 10;
 		tmp.z = 15;
+		tmp.m = 20;
 		sequence.add(tmp); // insert copy of tmp
 		const size_t sizeTwo = 2;
 		
@@ -261,9 +271,10 @@ namespace tut
 		ensure_equals( sequence.getAt(0).x, 1 );
 		ensure_equals( sequence.getAt(0).y, 2 );
 		ensure_equals( sequence.getAt(0).z, 3 );
+		ensure_equals( sequence.getAt(0).m, 4 );
 		ensure_equals( sequence.getAt(1).x, 5 );
 		ensure_equals( sequence.getAt(1).y, 10 );
-		ensure_equals( sequence.getAt(1).z, 15 );
+		ensure_equals( sequence.getAt(1).m, 20 );
 	}
 
     // Test of setAt()
@@ -282,17 +293,18 @@ namespace tut
 		ensure( sequence.hasRepeatedPoints() );
 
 		// Set new values to first coordinate
-		Coordinate first(1, 2, 3);
+		Coordinate first(1, 2, 3, 4);
 		sequence.setAt(first, 0);
 
 		ensure_equals( sequence.size(), size );
 		ensure_equals( sequence.getAt(0).x, 1 );
 		ensure_equals( sequence.getAt(0).y, 2 );
 		ensure_equals( sequence.getAt(0).z, 3 );
+		ensure_equals( sequence.getAt(0).m, 4 );
 
 
 		// Set new values to second coordinate 
-		Coordinate second(5, 10, 15);
+		Coordinate second(5, 10, 15, 20);
 		sequence.setAt(second, 1);
 
 		ensure_equals( sequence.size(), size );
@@ -300,6 +312,7 @@ namespace tut
 		ensure_equals( sequence.getAt(1).x, 5 );
 		ensure_equals( sequence.getAt(1).y, 10 );
 		ensure_equals( sequence.getAt(1).z, 15 );
+		ensure_equals( sequence.getAt(1).m, 20 );
 
 		ensure( !sequence.hasRepeatedPoints() );
 	}
@@ -367,9 +380,9 @@ namespace tut
 		// Create collection of points
 		const std::vector<Coordinate>::size_type sizeCol = 3;
 		std::vector<Coordinate> col;
-		col.push_back(Coordinate(1, 2, 3));
-		col.push_back(Coordinate(5, 10, 15));
-		col.push_back(Coordinate(9, 18, 27));
+		col.push_back(Coordinate(1, 2, 3, 4));
+		col.push_back(Coordinate(5, 10, 15, 20));
+		col.push_back(Coordinate(9, 18, 27, 36));
 
 		ensure( "std::vector bug assumed!", !col.empty() );
 		ensure_equals( "std::vector bug assumed!", col.size(), sizeCol );
@@ -385,14 +398,17 @@ namespace tut
 		ensure_equals( sequence.getAt(0).x, 1 );
 		ensure_equals( sequence.getAt(0).y, 2 );
 		ensure_equals( sequence.getAt(0).z, 3 );
+		ensure_equals( sequence.getAt(0).m, 4 );
 
 		ensure_equals( sequence.getAt(1).x, 5 );
 		ensure_equals( sequence.getAt(1).y, 10 );
 		ensure_equals( sequence.getAt(1).z, 15 );
+		ensure_equals( sequence.getAt(1).m, 20 );
 
 		ensure_equals( sequence.getAt(2).x, 9 );
 		ensure_equals( sequence.getAt(2).y, 18 );
 		ensure_equals( sequence.getAt(2).z, 27 );
+		ensure_equals( sequence.getAt(2).m, 36 );
 	}
 
 	// Test of removeRepeatedPoints
@@ -479,7 +495,7 @@ namespace tut
 		using geos::geom::CoordinateArraySequence;
 		using geos::geom::CoordinateSequence;
 
-		Coordinate c1(1, 2, 3);
+		Coordinate c1(1, 2, 3, 4);
 
 		CoordinateArraySequence sequence1;
 
@@ -487,14 +503,17 @@ namespace tut
 
 		ensure_equals( sequence1[0], c1 );
 
-		sequence1.setOrdinate(0, CoordinateSequence::X, 4);
-		ensure_equals( sequence1[0].x, 4 );
+		sequence1.setOrdinate(0, CoordinateSequence::X, 5);
+		ensure_equals( sequence1[0].x, 5 );
 
-		sequence1.setOrdinate(0, CoordinateSequence::Y, 5);
-		ensure_equals( sequence1[0].y, 5 );
+		sequence1.setOrdinate(0, CoordinateSequence::Y, 6);
+		ensure_equals( sequence1[0].y, 6 );
 
-		sequence1.setOrdinate(0, CoordinateSequence::Z, 6);
-		ensure_equals( sequence1[0].z, 6 );
+		sequence1.setOrdinate(0, CoordinateSequence::Z, 7);
+		ensure_equals( sequence1[0].z, 7 );
+
+		sequence1.setOrdinate(0, CoordinateSequence::M, 8);
+		ensure_equals( sequence1[0].m, 8 );
 
 	}
 
@@ -507,7 +526,7 @@ namespace tut
 		using geos::geom::CoordinateArraySequence;
 		using geos::geom::CoordinateSequence;
 
-		Coordinate c1(1, 2, 3);
+		Coordinate c1(1, 2, 3, 4);
 
 		CoordinateArraySequence sequence1;
 
@@ -515,16 +534,19 @@ namespace tut
 
 		ensure_equals( sequence1[0], c1 );
 
-		// Order: Y, X, Z
+		// Order: Y, X, Z, M
 
-		sequence1.setOrdinate(0, CoordinateSequence::Y, 5);
-		ensure_equals( sequence1[0].y, 5 );
+		sequence1.setOrdinate(0, CoordinateSequence::Y, 6);
+		ensure_equals( sequence1[0].y, 6 );
 
-		sequence1.setOrdinate(0, CoordinateSequence::X, 4);
-		ensure_equals( sequence1[0].x, 4 );
+		sequence1.setOrdinate(0, CoordinateSequence::X, 5);
+		ensure_equals( sequence1[0].x, 5 );
 
-		sequence1.setOrdinate(0, CoordinateSequence::Z, 6);
-		ensure_equals( sequence1[0].z, 6 );
+		sequence1.setOrdinate(0, CoordinateSequence::Z, 7);
+		ensure_equals( sequence1[0].z, 7 );
+
+		sequence1.setOrdinate(0, CoordinateSequence::M, 8);
+		ensure_equals( sequence1[0].m, 8 );
 
 	}
 
@@ -544,29 +566,33 @@ namespace tut
 		std::auto_ptr<CoordinateSequence> sequence1ptr(factory->create(4, 2));
 		CoordinateSequence& seq = *sequence1ptr;
 
-		// Index: 0 - Order: Y, X, Z
+		// Index: 0 - Order: Y, X, Z, M
 
 		seq.setOrdinate(0, CoordinateSequence::Y,  5); ensure_equals( seq[0].y, 5 );
 		seq.setOrdinate(0, CoordinateSequence::Z,  6); ensure_equals( seq[0].z, 6 );
 		seq.setOrdinate(0, CoordinateSequence::X,  4); ensure_equals( seq[0].x, 4 );
+		seq.setOrdinate(0, CoordinateSequence::M,  7); ensure_equals( seq[0].m, 7 );
 
-		// Index: 1 - Order: Z, X, Y
+		// Index: 1 - Order: Z, X, Y, M
 
 		seq.setOrdinate(1, CoordinateSequence::Z,  9); ensure_equals( seq[1].z, 9 );
 		seq.setOrdinate(1, CoordinateSequence::X,  8); ensure_equals( seq[1].x, 8 );
 		seq.setOrdinate(1, CoordinateSequence::Y,  7); ensure_equals( seq[1].y, 7 );
+		seq.setOrdinate(1, CoordinateSequence::M,  10); ensure_equals( seq[1].m, 10 );
 
-		// Index: 2 - Order: X, Y, Z
+		// Index: 2 - Order: X, Y, Z, M
 
 		seq.setOrdinate(2, CoordinateSequence::X,  34); ensure_equals( seq[2].x, 34 );
 		seq.setOrdinate(2, CoordinateSequence::Y,  -45); ensure_equals( seq[2].y, -45 );
 		seq.setOrdinate(2, CoordinateSequence::Z,  152); ensure_equals( seq[2].z, 152 );
+		seq.setOrdinate(2, CoordinateSequence::M,  -163); ensure_equals( seq[2].m, -163 );
 
-		// Index: 3 - Order: Y, Z, X
+		// Index: 3 - Order: Y, Z, X, M
 
 		seq.setOrdinate(3, CoordinateSequence::Y,  63); ensure_equals( seq[3].y, 63 );
 		seq.setOrdinate(3, CoordinateSequence::Z,  13); ensure_equals( seq[3].z, 13 );
 		seq.setOrdinate(3, CoordinateSequence::X,  -65); ensure_equals( seq[3].x, -65 );
+		seq.setOrdinate(3, CoordinateSequence::M,  -13); ensure_equals( seq[3].m, -13 );
 
 	}
 

--- a/tests/unit/geom/EnvelopeTest.cpp
+++ b/tests/unit/geom/EnvelopeTest.cpp
@@ -146,11 +146,12 @@ namespace tut
         ensure( !small.contains( 5, 5 ) );
 
         // Test coordinate
-        geos::geom::Coordinate origin(0, 0, 0);
+        geos::geom::Coordinate origin(0, 0, 0, 0);
 
         ensure_equals( origin.x, 0 );
         ensure_equals( origin.y, 0 );
         ensure_equals( origin.z, 0 );
+        ensure_equals( origin.m, 0 );
         ensure( small.contains( origin ) );
     }
 
@@ -185,11 +186,12 @@ namespace tut
         ensure( !with_origin.intersects( -200, 200 ) );
 
         // Test intersection with coordinate
-        geos::geom::Coordinate origin(0, 0, 0);
+        geos::geom::Coordinate origin(0, 0, 0, 0);
 
         ensure_equals( origin.x, 0 );
         ensure_equals( origin.y, 0 );
         ensure_equals( origin.z, 0 );
+        ensure_equals( origin.m, 0 );
         ensure( with_origin.intersects( origin ) );
 
     }

--- a/tests/unit/geom/EnvelopeTest.cpp
+++ b/tests/unit/geom/EnvelopeTest.cpp
@@ -146,12 +146,18 @@ namespace tut
         ensure( !small.contains( 5, 5 ) );
 
         // Test coordinate
+#ifdef GEOS_MVALUES
         geos::geom::Coordinate origin(0, 0, 0, 0);
+#else
+        geos::geom::Coordinate origin(0, 0, 0);
+#endif
 
         ensure_equals( origin.x, 0 );
         ensure_equals( origin.y, 0 );
         ensure_equals( origin.z, 0 );
+#ifdef GEOS_MVALUES
         ensure_equals( origin.m, 0 );
+#endif
         ensure( small.contains( origin ) );
     }
 
@@ -186,12 +192,18 @@ namespace tut
         ensure( !with_origin.intersects( -200, 200 ) );
 
         // Test intersection with coordinate
+#ifdef GEOS_MVALUES
         geos::geom::Coordinate origin(0, 0, 0, 0);
+#else
+        geos::geom::Coordinate origin(0, 0, 0);
+#endif
 
         ensure_equals( origin.x, 0 );
         ensure_equals( origin.y, 0 );
         ensure_equals( origin.z, 0 );
+#ifdef GEOS_MVALUES
         ensure_equals( origin.m, 0 );
+#endif
         ensure( with_origin.intersects( origin ) );
 
     }

--- a/tests/unit/geom/GeometryFactoryTest.cpp
+++ b/tests/unit/geom/GeometryFactoryTest.cpp
@@ -51,6 +51,7 @@ namespace tut
         const int x_;
         const int y_;
         const int z_;
+        const int m_;
 
         const int srid_;
         geos::geom::PrecisionModel pm_;
@@ -58,7 +59,7 @@ namespace tut
         geos::io::WKTReader reader_;
 
         test_geometryfactory_data()
-            : x_(5), y_(10), z_(15), srid_(666), pm_(1.0), factory_(&pm_, srid_), reader_(&factory_)
+            : x_(5), y_(10), z_(15), m_(20), srid_(666), pm_(1.0), factory_(&pm_, srid_), reader_(&factory_)
         {}
     private:
         // Declare type as noncopyable
@@ -278,7 +279,7 @@ namespace tut
 	template<>
 	void object::test<9>()
 	{
-		geos::geom::Coordinate coord(x_, y_, z_);
+		geos::geom::Coordinate coord(x_, y_, z_, m_);
 
 		PointPtr pt = factory_.createPoint(coord);
 
@@ -293,6 +294,7 @@ namespace tut
 		ensure_equals( pcoord->x, x_ );
 		ensure_equals( pcoord->y, y_ );
 		ensure_equals( pcoord->z, z_ );
+		ensure_equals( pcoord->m, m_ );
 
 		GeometryPtr geo = 0;
 		geo = pt->getEnvelope();
@@ -331,7 +333,7 @@ namespace tut
 	template<>
 	void object::test<10>()
 	{
-		geos::geom::Coordinate coord(x_, y_, z_);
+		geos::geom::Coordinate coord(x_, y_, z_, m_);
 
 		CoordArrayPtr sequence = new geos::geom::CoordinateArraySequence();
 
@@ -351,6 +353,7 @@ namespace tut
 		ensure_equals( pcoord->x, x_ );
 		ensure_equals( pcoord->y, y_ );
 		ensure_equals( pcoord->z, z_ );
+		ensure_equals( pcoord->m, m_ );
 
 		GeometryPtr geo = 0;
 		geo = pt->getEnvelope();
@@ -389,7 +392,7 @@ namespace tut
 	template<>
 	void object::test<11>()
 	{
-		geos::geom::Coordinate coord(x_, y_, z_);
+		geos::geom::Coordinate coord(x_, y_, z_, m_);
 
 		geos::geom::CoordinateArraySequence sequence;
 		sequence.add(coord);
@@ -407,6 +410,7 @@ namespace tut
 		ensure_equals( pcoord->x, x_ );
 		ensure_equals( pcoord->y, y_ );
 		ensure_equals( pcoord->z, z_ );
+		ensure_equals( pcoord->m, m_ );
 
 		GeometryPtr geo = 0;
 		geo = pt->getEnvelope();
@@ -840,7 +844,7 @@ namespace tut
 		std::vector<GeometryPtr>* vec = new std::vector<GeometryPtr>();
 
 		// Add single point
-		Coordinate coord(x_, y_, z_);
+		Coordinate coord(x_, y_, z_, m_);
 		GeometryPtr point = factory_.createPoint(coord);
 		ensure( point != 0 );
 		vec->push_back(point);
@@ -871,7 +875,7 @@ namespace tut
 	void object::test<23>()
 	{
 		const std::size_t size = 3;
-		geos::geom::Coordinate coord(x_, y_, z_);
+		geos::geom::Coordinate coord(x_, y_, z_, m_);
 
 		std::vector<GeometryPtr> vec;
 
@@ -882,12 +886,14 @@ namespace tut
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
+		coord.m *= 2;
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
+		coord.m *= 3;
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
@@ -955,7 +961,7 @@ namespace tut
 	void object::test<25>()
 	{
 		const std::size_t size = 3;
-		geos::geom::Coordinate coord(x_, y_, z_);
+		geos::geom::Coordinate coord(x_, y_, z_, m_);
 
 		std::vector<GeometryPtr>* vec = new std::vector<GeometryPtr>();
 
@@ -967,6 +973,7 @@ namespace tut
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
+		coord.m *= 2;
 		geo = factory_.createPoint(coord);
 		ensure( geo != 0 );
 		vec->push_back(geo);
@@ -974,6 +981,7 @@ namespace tut
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
+		coord.m *= 3;
 		geo = factory_.createPoint(coord);
 		ensure( geo != 0 );
 		vec->push_back(geo);
@@ -996,7 +1004,7 @@ namespace tut
 	void object::test<26>()
 	{
 		const std::size_t size = 3;
-		geos::geom::Coordinate coord(x_, y_, z_);
+		geos::geom::Coordinate coord(x_, y_, z_, m_);
 
 		std::vector<GeometryPtr> vec;
 
@@ -1007,12 +1015,14 @@ namespace tut
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
+		coord.m *= 2;
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
+		coord.m *= 3;
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
@@ -1246,7 +1256,7 @@ namespace tut
 		typedef std::vector<PointPtr> PointVect;
 
 		const std::size_t size = 3;
-		geos::geom::Coordinate coord(x_, y_, z_);
+		geos::geom::Coordinate coord(x_, y_, z_, m_);
 
 		PointVect vec;
 
@@ -1257,12 +1267,14 @@ namespace tut
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
+		coord.m *= 2;
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
+		coord.m *= 3;
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 

--- a/tests/unit/geom/GeometryFactoryTest.cpp
+++ b/tests/unit/geom/GeometryFactoryTest.cpp
@@ -279,7 +279,11 @@ namespace tut
 	template<>
 	void object::test<9>()
 	{
+#ifdef GEOS_MVALUES
 		geos::geom::Coordinate coord(x_, y_, z_, m_);
+#else
+		geos::geom::Coordinate coord(x_, y_, z_);
+#endif
 
 		PointPtr pt = factory_.createPoint(coord);
 
@@ -294,7 +298,9 @@ namespace tut
 		ensure_equals( pcoord->x, x_ );
 		ensure_equals( pcoord->y, y_ );
 		ensure_equals( pcoord->z, z_ );
+#ifdef GEOS_MVALUES
 		ensure_equals( pcoord->m, m_ );
+#endif
 
 		GeometryPtr geo = 0;
 		geo = pt->getEnvelope();
@@ -333,7 +339,11 @@ namespace tut
 	template<>
 	void object::test<10>()
 	{
+#ifdef GEOS_MVALUES
 		geos::geom::Coordinate coord(x_, y_, z_, m_);
+#else
+		geos::geom::Coordinate coord(x_, y_, z_);
+#endif
 
 		CoordArrayPtr sequence = new geos::geom::CoordinateArraySequence();
 
@@ -353,7 +363,9 @@ namespace tut
 		ensure_equals( pcoord->x, x_ );
 		ensure_equals( pcoord->y, y_ );
 		ensure_equals( pcoord->z, z_ );
+#ifdef GEOS_MVALUES
 		ensure_equals( pcoord->m, m_ );
+#endif
 
 		GeometryPtr geo = 0;
 		geo = pt->getEnvelope();
@@ -392,7 +404,11 @@ namespace tut
 	template<>
 	void object::test<11>()
 	{
+#ifdef GEOS_MVALUES
 		geos::geom::Coordinate coord(x_, y_, z_, m_);
+#else
+		geos::geom::Coordinate coord(x_, y_, z_);
+#endif
 
 		geos::geom::CoordinateArraySequence sequence;
 		sequence.add(coord);
@@ -410,7 +426,9 @@ namespace tut
 		ensure_equals( pcoord->x, x_ );
 		ensure_equals( pcoord->y, y_ );
 		ensure_equals( pcoord->z, z_ );
+#ifdef GEOS_MVALUES
 		ensure_equals( pcoord->m, m_ );
+#endif
 
 		GeometryPtr geo = 0;
 		geo = pt->getEnvelope();
@@ -844,7 +862,11 @@ namespace tut
 		std::vector<GeometryPtr>* vec = new std::vector<GeometryPtr>();
 
 		// Add single point
+#ifdef GEOS_MVALUES
 		Coordinate coord(x_, y_, z_, m_);
+#else
+		Coordinate coord(x_, y_, z_);
+#endif
 		GeometryPtr point = factory_.createPoint(coord);
 		ensure( point != 0 );
 		vec->push_back(point);
@@ -875,7 +897,11 @@ namespace tut
 	void object::test<23>()
 	{
 		const std::size_t size = 3;
+#ifdef GEOS_MVALUES
 		geos::geom::Coordinate coord(x_, y_, z_, m_);
+#else
+		geos::geom::Coordinate coord(x_, y_, z_);
+#endif
 
 		std::vector<GeometryPtr> vec;
 
@@ -886,14 +912,18 @@ namespace tut
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
+#ifdef GEOS_MVALUES
 		coord.m *= 2;
+#endif
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
+#ifdef GEOS_MVALUES
 		coord.m *= 3;
+#endif
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
@@ -961,7 +991,11 @@ namespace tut
 	void object::test<25>()
 	{
 		const std::size_t size = 3;
+#ifdef GEOS_MVALUES
 		geos::geom::Coordinate coord(x_, y_, z_, m_);
+#else
+		geos::geom::Coordinate coord(x_, y_, z_);
+#endif
 
 		std::vector<GeometryPtr>* vec = new std::vector<GeometryPtr>();
 
@@ -973,7 +1007,9 @@ namespace tut
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
+#ifdef GEOS_MVALUES
 		coord.m *= 2;
+#endif
 		geo = factory_.createPoint(coord);
 		ensure( geo != 0 );
 		vec->push_back(geo);
@@ -981,7 +1017,9 @@ namespace tut
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
+#ifdef GEOS_MVALUES
 		coord.m *= 3;
+#endif
 		geo = factory_.createPoint(coord);
 		ensure( geo != 0 );
 		vec->push_back(geo);
@@ -1004,7 +1042,11 @@ namespace tut
 	void object::test<26>()
 	{
 		const std::size_t size = 3;
+#ifdef GEOS_MVALUES
 		geos::geom::Coordinate coord(x_, y_, z_, m_);
+#else
+		geos::geom::Coordinate coord(x_, y_, z_);
+#endif
 
 		std::vector<GeometryPtr> vec;
 
@@ -1015,14 +1057,18 @@ namespace tut
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
+#ifdef GEOS_MVALUES
 		coord.m *= 2;
+#endif
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
+#ifdef GEOS_MVALUES
 		coord.m *= 3;
+#endif
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
@@ -1256,7 +1302,11 @@ namespace tut
 		typedef std::vector<PointPtr> PointVect;
 
 		const std::size_t size = 3;
+#ifdef GEOS_MVALUES
 		geos::geom::Coordinate coord(x_, y_, z_, m_);
+#else
+		geos::geom::Coordinate coord(x_, y_, z_);
+#endif
 
 		PointVect vec;
 
@@ -1267,14 +1317,18 @@ namespace tut
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
+#ifdef GEOS_MVALUES
 		coord.m *= 2;
+#endif
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
+#ifdef GEOS_MVALUES
 		coord.m *= 3;
+#endif
 		geo = factory_.createPoint(coord);
 		vec.push_back(geo);
 

--- a/tests/unit/geom/TriangleTest.cpp
+++ b/tests/unit/geom/TriangleTest.cpp
@@ -116,6 +116,7 @@ namespace tut
 		ensure( center.y > 4.2 );
 		ensure( center.y < 4.3 );
 		ensure( 0 != ISNAN( center.z ) );
+		ensure( 0 != ISNAN( center.m ) );
     }
     // Test circumcentre()
         template<>
@@ -149,6 +150,7 @@ namespace tut
 		ensure_equals(c1.x ,2 );
 		ensure_equals(c1.y ,3 );
 		ensure( 0 != ISNAN( c1.z ) );
+		ensure( 0 != ISNAN( c1.m ) );
 
 		//For t2:
 		Coordinate c2(0,0);
@@ -156,6 +158,7 @@ namespace tut
 		ensure_equals(c2.x ,30.5 );
 		ensure_equals(c2.y ,- 14.5 );
 		ensure( 0 != ISNAN( c2.z ) );
+		ensure( 0 != ISNAN( c2.m ) );
 
 
 		//For t3:
@@ -165,6 +168,7 @@ namespace tut
 		ensure( c3.y > 13.7 );
 		ensure( c3.y < 13.8 );
 		ensure( 0 != ISNAN( c3.z ) );
+		ensure( 0 != ISNAN( c3.m ) );
 		// cout << "CicumCenter of triangle ABC:: " << c1.x << " " << c1.y << endl;
 
 		//  std::cout << "CicumCenter of triangle DEF:: " << c2.x << " " << c2.y << std::endl;

--- a/tests/unit/geom/TriangleTest.cpp
+++ b/tests/unit/geom/TriangleTest.cpp
@@ -116,7 +116,9 @@ namespace tut
 		ensure( center.y > 4.2 );
 		ensure( center.y < 4.3 );
 		ensure( 0 != ISNAN( center.z ) );
+#ifdef GEOS_MVALUES
 		ensure( 0 != ISNAN( center.m ) );
+#endif
     }
     // Test circumcentre()
         template<>
@@ -150,7 +152,9 @@ namespace tut
 		ensure_equals(c1.x ,2 );
 		ensure_equals(c1.y ,3 );
 		ensure( 0 != ISNAN( c1.z ) );
+#ifdef GEOS_MVALUES
 		ensure( 0 != ISNAN( c1.m ) );
+#endif
 
 		//For t2:
 		Coordinate c2(0,0);
@@ -158,7 +162,9 @@ namespace tut
 		ensure_equals(c2.x ,30.5 );
 		ensure_equals(c2.y ,- 14.5 );
 		ensure( 0 != ISNAN( c2.z ) );
+#ifdef GEOS_MVALUES
 		ensure( 0 != ISNAN( c2.m ) );
+#endif
 
 
 		//For t3:
@@ -168,7 +174,9 @@ namespace tut
 		ensure( c3.y > 13.7 );
 		ensure( c3.y < 13.8 );
 		ensure( 0 != ISNAN( c3.z ) );
+#ifdef GEOS_MVALUES
 		ensure( 0 != ISNAN( c3.m ) );
+#endif
 		// cout << "CicumCenter of triangle ABC:: " << c1.x << " " << c1.y << endl;
 
 		//  std::cout << "CicumCenter of triangle DEF:: " << c2.x << " " << c2.y << std::endl;

--- a/tests/unit/io/WKTReaderTest.cpp
+++ b/tests/unit/io/WKTReaderTest.cpp
@@ -92,7 +92,7 @@ namespace tut
             delete coords;
     }
 
-	// 4 - Ensure we can read ZM geometries
+	// 4 - Ensure we can read ZM geometries (discarding M if GEOS compiled without M support)
 	template<>
 	template<>
 	void object::test<4>()
@@ -100,12 +100,17 @@ namespace tut
             GeomPtr geom(wktreader.read("LINESTRING ZM (-117 33 2 3, -116 34 4 5)"));
             geos::geom::CoordinateSequence *coords = geom->getCoordinates();
 
+#ifdef GEOS_MVALUES
             ensure( coords->getDimension() == 4 );
-
             wktwriter.setOutputDimension( 4 );
             ensure_equals( wktwriter.write(geom.get()), 
                      std::string("LINESTRING ZM (-117 33 2 3, -116 34 4 5)") );
-
+#else
+            ensure( coords->getDimension() == 3 );
+            wktwriter.setOutputDimension( 3 );
+            ensure_equals( wktwriter.write(geom.get()), 
+                     std::string("LINESTRING Z (-117 33 2, -116 34 4)") );
+#endif
             delete coords;
     }
 
@@ -190,6 +195,7 @@ namespace tut
 			delete coords;
 	}
 
+#ifdef GEOS_MVALUES
 	// 9 - Ensure we can read M geometries
 	template<>
 	template<>
@@ -227,6 +233,8 @@ namespace tut
 
 			delete coords;
 	}
+#endif
+
 } // namespace tut
 
 

--- a/tests/unit/io/WKTReaderTest.cpp
+++ b/tests/unit/io/WKTReaderTest.cpp
@@ -38,7 +38,6 @@ namespace tut
 			gf(&pm),
 			wktreader(&gf)
 		{
-            wktwriter.setOutputDimension( 3 );
         }
 
 	};
@@ -93,7 +92,7 @@ namespace tut
             delete coords;
     }
 
-	// 4 - Ensure we can read ZM geometries, just discarding the M.
+	// 4 - Ensure we can read ZM geometries
 	template<>
 	template<>
 	void object::test<4>()
@@ -101,10 +100,11 @@ namespace tut
             GeomPtr geom(wktreader.read("LINESTRING ZM (-117 33 2 3, -116 34 4 5)"));
             geos::geom::CoordinateSequence *coords = geom->getCoordinates();
 
-            ensure( coords->getDimension() == 3 );
+            ensure( coords->getDimension() == 4 );
 
+            wktwriter.setOutputDimension( 4 );
             ensure_equals( wktwriter.write(geom.get()), 
-                           std::string("LINESTRING Z (-117 33 2, -116 34 4)") );
+                     std::string("LINESTRING ZM (-117 33 2 3, -116 34 4 5)") );
 
             delete coords;
     }
@@ -115,6 +115,7 @@ namespace tut
 	void object::test<5>()
 	{         
             GeomPtr geom(wktreader.read("LineString (-117 33 2, -116 34 4)"));
+			wktwriter.setOutputDimension( 3 );
             ensure_equals( wktwriter.write(geom.get()), 
                            std::string("LINESTRING Z (-117 33 2, -116 34 4)") );
     }
@@ -137,7 +138,7 @@ namespace tut
         }
     }
 
-    // POINT(0 0) http://trac.osgeo.org/geos/ticket/610
+	// 7- POINT(0 0) http://trac.osgeo.org/geos/ticket/610
     template<>
     template<>
     void object::test<7>()
@@ -171,6 +172,61 @@ namespace tut
             ensure( !"Got unexpected exception" );
         }
     }
+
+	// 8 - Ensure we can read Z geometries
+	template<>
+	template<>
+	void object::test<8>()
+	{
+			GeomPtr geom(wktreader.read("LINESTRING Z (-117 33 2, -116 34 4)"));
+			geos::geom::CoordinateSequence *coords = geom->getCoordinates();
+
+			ensure( coords->getDimension() == 3 );
+
+			wktwriter.setOutputDimension( 3 );
+			ensure_equals( wktwriter.write(geom.get()),
+						   std::string("LINESTRING Z (-117 33 2, -116 34 4)") );
+
+			delete coords;
+	}
+
+	// 9 - Ensure we can read M geometries
+	template<>
+	template<>
+	void object::test<9>()
+	{
+			GeomPtr geom(wktreader.read("LINESTRING M (-117 33 2, -116 34 4)"));
+			geos::geom::CoordinateSequence *coords = geom->getCoordinates();
+
+			ensure( coords->getDimension() == 3 );
+
+			wktwriter.setOutputDimension( 3 );
+			ensure_equals( wktwriter.write(geom.get()),
+						   std::string("LINESTRING M (-117 33 2, -116 34 4)") );
+
+			delete coords;
+	}
+
+	// 10 - Ensure we can output only XYZ or XYM of XYZM geometries
+	template<>
+	template<>
+	void object::test<10>()
+	{
+			GeomPtr geom(wktreader.read("LINESTRING ZM (-117 33 2 3, -116 34 4 5)"));
+			geos::geom::CoordinateSequence *coords = geom->getCoordinates();
+
+			ensure( coords->getDimension() == 4 );
+
+			wktwriter.setOutputDimension( 3 );
+			ensure_equals( wktwriter.write(geom.get()),
+						   std::string("LINESTRING Z (-117 33 2, -116 34 4)") );
+
+			wktwriter.setOutputDimension( 3, true );
+			ensure_equals( wktwriter.write(geom.get()),
+						   std::string("LINESTRING M (-117 33 3, -116 34 5)") );
+
+			delete coords;
+	}
 } // namespace tut
 
 

--- a/tests/unit/linearref/LengthIndexedLineTest.cpp
+++ b/tests/unit/linearref/LengthIndexedLineTest.cpp
@@ -402,7 +402,9 @@ void object::test<25>()
     double projIndex = indexedLine.project(Coordinate(5, 5));
     Coordinate projPt = indexedLine.extractPoint(projIndex);
     ensure(0 != ISNAN(projPt.z));
+#ifdef GEOS_MVALUES
     ensure(0 != ISNAN(projPt.m));
+#endif
 }
 
 /**

--- a/tests/unit/linearref/LengthIndexedLineTest.cpp
+++ b/tests/unit/linearref/LengthIndexedLineTest.cpp
@@ -388,7 +388,7 @@ void object::test<24>()
 }
 
 /**
- * Tests that if the input does not have Z ordinates, neither does the output.
+ * Tests that if the input does not have Z and M ordinates, neither does the output.
  *
  */
 // testComputeZNaN()
@@ -402,6 +402,7 @@ void object::test<25>()
     double projIndex = indexedLine.project(Coordinate(5, 5));
     Coordinate projPt = indexedLine.extractPoint(projIndex);
     ensure(0 != ISNAN(projPt.z));
+    ensure(0 != ISNAN(projPt.m));
 }
 
 /**

--- a/tests/xmltester/Makefile.am
+++ b/tests/xmltester/Makefile.am
@@ -134,7 +134,7 @@ XMLTester_LDADD = $(LIBS)
 
 # Intentionally drop -ansi -pedantic
 # See http://trac.osgeo.org/geos/ticket/319
-XMLTester_CXXFLAGS = $(INLINE_FLAGS)
+XMLTester_CXXFLAGS = $(INLINE_FLAGS) $(MVALUES_FLAGS)
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/io/tinyxml -DTIXML_USE_STL


### PR DESCRIPTION
RFC

Overall remark: the patch is pretty invasive for the reason that it adds support for M-values with and without Z-values (the occasional reference to future M-value support in the original code seem to indicate that a possible 3rd dimension was always to be Z and a possible 4th dimension always M).

All tests still pass with this patch.

In short, this patch removes internal `dimension` variables, using instead variables such as `hasZ` and `hasM` (with `dimension` getters then returning `2 + hasZ + hasM`). It adjusts WKT and WKB readers to correctly handle combinations of XY, XYZ, XYM and XYZM geometries. It also introduces various `interpolateM` style functions, which are copies of the respective `interpolateZ` functions (with the exception of `ElevationMatrix` related methods which I suppose don't make sense for M values).

A C++ API break was introduced with the `Coordinate{Array}Sequence` constructors. For the rest, compatibility is preserved.

Questions:
- Does the old WKT style only handle possible 3D values (i.e. `POINT (1 2 3)`), or also Z _and_ M (i.e. `POINT (1 2 3 4)`)?
- C-API: how to deal with XYM geometries? This needs to be considered in the following functions:
  
  GEOSCoordSeq_create(handle, size, dims)
  GEOSWKTWriter_setOutputDimension(handle, writer, dim)
  GEOSWKBWriter_setOutputDimension(writer, newDimension)

Both these now accept `4` as dimension for XYZM geometries, and `3` means XYZ as before. For XYM geometries, I suppose the only solution is to add new functions such as 

```
GEOSCoordSeq_create_zm(handle, size, hasZ, hasM)
GEOSWKTWriter_setOutputDimension_zm(handle, writer, hasZ, hasM)
GEOSWKBWriter_setOutputDimension_zm(writer, hasZ, hasM)
```
