### PR TITLE
Fix cmake build with Visual Studio 2015

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ elseif(MSVC)
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
   string(REGEX REPLACE "/W[0-9]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
-  if(MSVC80 OR MSVC90 OR MSVC10 OR MSVC11 OR MSVC12 OR MSVC13)
+  if(NOT (MSVC_VERSION LESS 1400)) # Visual Studio 2005 or later
 
     # Option is to enable the /MP switch for Visual Studio 2005 or later
     option(GEOS_MSVC_ENABLE_MP


### PR DESCRIPTION
This PR replaces the explicit Visual Studio Version enumeration in CMakeLists.txt with a single check for Visual Studio 2005 or later which seems to have been the intent of the if statement from the beginning. With this cmake can be used to build with Visual Studio 2015.