### PR TITLE
Add autoDestroy method to GeometryFactory

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -838,6 +838,12 @@ GEOSGeom_clone(const Geometry *g)
     return GEOSGeom_clone_r( handle, g );
 }
 
+GEOSGeometry *
+GEOSGeom_setPrecision(const GEOSGeometry *g, double gridSize, int forceSnap)
+{
+	return GEOSGeom_setPrecision_r(handle, g, gridSize, forceSnap);
+}
+
 int
 GEOSGeom_getDimensions(const Geometry *g)
 {

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -941,6 +941,26 @@ extern const GEOSGeometry GEOS_DLL *GEOSGetGeometryN_r(
 extern int GEOS_DLL GEOSNormalize_r(GEOSContextHandle_t handle,
                                     GEOSGeometry* g);
 
+/**
+ * Set the geometry's precision, optionally rounding all its
+ * coordinates to the precision grid (if it changes).
+ *
+ * @param gridSize size of the precision grid, or 0 for FLOATING
+ *                 precision.
+ * @param forceSnap specifies whether snapping to the precision grid
+ *                  should be forced: -1 prevents snapping, which can
+ *                  be used when the input is known to be already
+ *                  rounded to the target grid; 0 only snaps if the
+ *                  new precision grid is not equal or compatible with
+ *                  the new precision grid; 1 always snaps.
+ * @retuns NULL on exception or a new GEOSGeometry object
+ *
+ */
+extern GEOSGeometry GEOS_DLL *GEOSGeom_setPrecision_r(
+                                       GEOSContextHandle_t handle,
+                                       const GEOSGeometry *g,
+                                       double gridSize, int forceSnap);
+
 /* Return -1 on exception */
 extern int GEOS_DLL GEOSGetNumInteriorRings_r(GEOSContextHandle_t handle,
                                               const GEOSGeometry* g);
@@ -1686,6 +1706,10 @@ extern const GEOSGeometry GEOS_DLL *GEOSGetGeometryN(const GEOSGeometry* g, int 
 
 /* Return -1 on exception */
 extern int GEOS_DLL GEOSNormalize(GEOSGeometry* g);
+
+/* Return -1 on exception */
+extern GEOSGeometry GEOS_DLL *GEOSGeom_setPrecision(
+	const GEOSGeometry *g, double gridSize, int forceSnap);
 
 /* Return -1 on exception */
 extern int GEOS_DLL GEOSGetNumInteriorRings(const GEOSGeometry* g);

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -4255,7 +4255,9 @@ GEOSGeom_setPrecision_r(GEOSContextHandle_t extHandle, const GEOSGeometry *g,
         std::auto_ptr<PrecisionModel> newpm;
         if ( gridSize ) newpm.reset( new PrecisionModel(1.0/gridSize) );
         else newpm.reset( new PrecisionModel() );
-        std::auto_ptr<GeometryFactory> gf ( new GeometryFactory(newpm.get()) );
+        std::auto_ptr<GeometryFactory> gf (
+            new GeometryFactory( newpm.get(), g->getSRID() )
+        );
         Geometry *ret;
         if ( gridSize && (
               forceSnap > 0 ||

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -61,6 +61,7 @@
 #include <geos/operation/sharedpaths/SharedPathsOp.h>
 #include <geos/operation/union/CascadedPolygonUnion.h>
 #include <geos/operation/valid/IsValidOp.h>
+#include <geos/precision/GeometryPrecisionReducer.h>
 #include <geos/linearref/LengthIndexedLine.h>
 #include <geos/triangulate/DelaunayTriangulationBuilder.h>
 #include <geos/triangulate/VoronoiDiagramBuilder.h>
@@ -132,6 +133,7 @@ using geos::operation::overlay::overlayOp;
 using geos::operation::geounion::CascadedPolygonUnion;
 using geos::operation::buffer::BufferParameters;
 using geos::operation::buffer::BufferBuilder;
+using geos::precision::GeometryPrecisionReducer;
 using geos::util::IllegalArgumentException;
 using geos::algorithm::distance::DiscreteHausdorffDistance;
 
@@ -4223,6 +4225,66 @@ GEOSGeom_clone_r(GEOSContextHandle_t extHandle, const Geometry *g)
         handle->ERROR_MESSAGE("Unknown exception thrown");
     }
     
+    return NULL;
+}
+
+GEOSGeometry *
+GEOSGeom_setPrecision_r(GEOSContextHandle_t extHandle, const GEOSGeometry *g,
+                                          double gridSize, int forceSnap)
+{
+    using namespace geos::geom;
+
+    assert(0 != g);
+
+    if ( 0 == extHandle )
+    {
+        return NULL;
+    }
+
+    GEOSContextHandleInternal_t *handle = 0;
+    handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+    if ( 0 == handle->initialized )
+    {
+        return NULL;
+    }
+
+    try
+    {
+        const PrecisionModel *pm = g->getPrecisionModel();
+        double cursize = pm->isFloating() ? 0 : 1.0/pm->getScale();
+        std::auto_ptr<PrecisionModel> newpm;
+        if ( gridSize ) newpm.reset( new PrecisionModel(1.0/gridSize) );
+        else newpm.reset( new PrecisionModel() );
+        std::auto_ptr<GeometryFactory> gf ( new GeometryFactory(newpm.get()) );
+        Geometry *ret;
+        if ( gridSize && (
+              forceSnap > 0 ||
+              ( forceSnap == 0 && cursize != gridSize )
+             )
+           )
+        {
+          // We need to snap the geometry
+          GeometryPrecisionReducer reducer( *gf );
+          ret = reducer.reduce( *g ).release();
+          gf.release()->autoDestroy();
+        }
+        else
+        {
+          // No need or willing to snap, just change the factory
+          ret = gf->createGeometry(g);
+          gf.release()->autoDestroy();
+        }
+        return ret;
+    }
+    catch (const std::exception &e)
+    {
+        handle->ERROR_MESSAGE("%s", e.what());
+    }
+    catch (...)
+    {
+        handle->ERROR_MESSAGE("Unknown exception thrown");
+    }
+
     return NULL;
 }
 

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -4255,9 +4255,8 @@ GEOSGeom_setPrecision_r(GEOSContextHandle_t extHandle, const GEOSGeometry *g,
         std::auto_ptr<PrecisionModel> newpm;
         if ( gridSize ) newpm.reset( new PrecisionModel(1.0/gridSize) );
         else newpm.reset( new PrecisionModel() );
-        std::auto_ptr<GeometryFactory> gf (
-            new GeometryFactory( newpm.get(), g->getSRID() )
-        );
+        GeometryFactory::unique_ptr gf =
+            GeometryFactory::create( newpm.get(), g->getSRID() );
         Geometry *ret;
         if ( gridSize && (
               forceSnap > 0 ||
@@ -4268,13 +4267,11 @@ GEOSGeom_setPrecision_r(GEOSContextHandle_t extHandle, const GEOSGeometry *g,
           // We need to snap the geometry
           GeometryPrecisionReducer reducer( *gf );
           ret = reducer.reduce( *g ).release();
-          gf.release()->autoDestroy();
         }
         else
         {
           // No need or willing to snap, just change the factory
           ret = gf->createGeometry(g);
-          gf.release()->autoDestroy();
         }
         return ret;
     }

--- a/doc/example.cpp
+++ b/doc/example.cpp
@@ -84,7 +84,7 @@ void wkt_print_geoms(vector<Geometry *> *geoms);
 // but that would be boring because you'd need to specify
 // a PrecisionModel and a SRID everytime: those infos are
 // cached inside a GeometryFactory object.
-GeometryFactory *global_factory;
+GeometryFactory::unique_ptr global_factory;
 
 //#define DEBUG_STREAM_STATE 1
 
@@ -335,7 +335,7 @@ create_simple_collection(vector<Geometry *> *geoms)
 Polygon *
 create_circle(double centerX, double centerY, double radius)
 {
-	geos::util::GeometricShapeFactory shapefactory(global_factory);
+	geos::util::GeometricShapeFactory shapefactory(global_factory.get());
 	shapefactory.setCentre(Coordinate(centerX, centerY));
 	shapefactory.setSize(radius);
 	// same as:
@@ -351,7 +351,7 @@ create_circle(double centerX, double centerY, double radius)
 Polygon *
 create_ellipse(double centerX, double centerY, double width, double height)
 {
-	geos::util::GeometricShapeFactory shapefactory(global_factory);
+	geos::util::GeometricShapeFactory shapefactory(global_factory.get());
 	shapefactory.setCentre(Coordinate(centerX, centerY));
 	shapefactory.setHeight(height);
 	shapefactory.setWidth(width);
@@ -366,7 +366,7 @@ create_ellipse(double centerX, double centerY, double width, double height)
 Polygon *
 create_rectangle(double llX, double llY, double width, double height)
 {
-	geos::util::GeometricShapeFactory shapefactory(global_factory);
+	geos::util::GeometricShapeFactory shapefactory(global_factory.get());
 	shapefactory.setBase(Coordinate(llX, llY));
 	shapefactory.setHeight(height);
 	shapefactory.setWidth(width);
@@ -383,7 +383,7 @@ create_rectangle(double llX, double llY, double width, double height)
 LineString *
 create_arc(double llX, double llY, double width, double height, double startang, double endang)
 {
-	geos::util::GeometricShapeFactory shapefactory(global_factory);
+	geos::util::GeometricShapeFactory shapefactory(global_factory.get());
 	shapefactory.setBase(Coordinate(llX, llY));
 	shapefactory.setHeight(height);
 	shapefactory.setWidth(width);
@@ -395,7 +395,7 @@ create_arc(double llX, double llY, double width, double height, double startang,
 auto_ptr<Polygon>
 create_sinestar(double cx, double cy, double size, int nArms, double armLenRat)
 {
-	geos::geom::util::SineStarFactory fact(global_factory);
+	geos::geom::util::SineStarFactory fact(global_factory.get());
 	fact.setCentre(Coordinate(cx, cy));
 	fact.setSize(size);
 	fact.setNumPoints(nArms*5);
@@ -416,7 +416,7 @@ void do_all()
 
 	// Initialize global factory with defined PrecisionModel
 	// and a SRID of -1 (undefined).
-	global_factory = new GeometryFactory(pm, -1);
+	global_factory = GeometryFactory::create(pm, -1);
 
 	// We do not need PrecisionMode object anymore, it has
 	// been copied to global_factory private storage
@@ -1080,8 +1080,6 @@ cout<<"-------------------------------------------------------------------------
 		delete (*geoms)[i];
 	}
 	delete geoms;
-
-	delete global_factory;
 }
 
 int

--- a/include/geos/geom/BinaryOp.h
+++ b/include/geos/geom/BinaryOp.h
@@ -469,12 +469,12 @@ BinaryOp(const Geometry* g0, const Geometry *g1, BinOp _Op)
 		for (double scale=maxScale; scale >= 1; scale /= 10)
 		{
 			PrecisionModel pm(scale);
-			GeometryFactory gf(&pm);
+			GeometryFactory::unique_ptr gf = GeometryFactory::create(&pm);
 #if GEOS_DEBUG_BINARYOP
 			std::cerr << "Trying with scale " << scale << std::endl;
 #endif
 
-			precision::GeometryPrecisionReducer reducer( gf );
+			precision::GeometryPrecisionReducer reducer( *gf );
 			GeomPtr rG0( reducer.reduce(*g0) );
 			GeomPtr rG1( reducer.reduce(*g1) );
 

--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -383,10 +383,25 @@ public:
 	/// Destroy a Geometry, or release it
 	void destroyGeometry(Geometry *g) const;
 
+	/// Request that the instance is deleted when last child Geometry is
+	/// deleted. Do not use the instance anymore after calling this function
+	/// (unless you're a live child!).
+	void autoDestroy();
+
 private:
+
 	const PrecisionModel* precisionModel;
 	int SRID;
 	const CoordinateSequenceFactory *coordinateListFactory;
+
+	mutable int _geometryCount;
+	bool _autoDestroy;
+
+friend class Geometry;
+
+	void addChild(const Geometry *g) const;
+	void delChild(const Geometry *g) const;
+
 };
 
 } // namespace geos::geom

--- a/include/geos/geom/GeometryFactory.h
+++ b/include/geos/geom/GeometryFactory.h
@@ -112,7 +112,7 @@ public:
 	 * the given {@link PrecisionModel} and spatial-reference ID,
 	 * and the default CoordinateSequence implementation.
 	 *
-	 * @param pm the PrecisionModel to use
+	 * @param pm the PrecisionModel to use, will be copied internally
 	 * @param newSRID the SRID to use
 	 */
 	GeometryFactory(const PrecisionModel* pm, int newSRID);

--- a/include/geos/operation/valid/ConnectedInteriorTester.h
+++ b/include/geos/operation/valid/ConnectedInteriorTester.h
@@ -23,6 +23,7 @@
 #include <geos/export.h>
 
 #include <geos/geom/Coordinate.h> // for composition
+#include <geos/geom/GeometryFactory.h> // for GeometryFactory::unique_ptr
 
 #include <vector>
 
@@ -83,7 +84,7 @@ protected:
 
 private:
 
-	geom::GeometryFactory *geometryFactory;
+	geom::GeometryFactory::unique_ptr geometryFactory;
 
 	geomgraph::GeometryGraph &geomGraph;
 

--- a/include/geos/precision/GeometryPrecisionReducer.h
+++ b/include/geos/precision/GeometryPrecisionReducer.h
@@ -20,6 +20,7 @@
 #define GEOS_PRECISION_GEOMETRYPRECISIONREDUCER_H
 
 #include <geos/export.h>
+#include <geos/geom/GeometryFactory.h> // for GeometryFactory::unique_ptr
 #include <memory> // for auto_ptr
 
 // Forward declarations
@@ -57,7 +58,7 @@ private:
   std::auto_ptr<geom::Geometry> fixPolygonalTopology(
                                                  const geom::Geometry& geom );
 
-  std::auto_ptr<geom::GeometryFactory> createFactory(
+  geom::GeometryFactory::unique_ptr createFactory(
                                           const geom::GeometryFactory& oldGF,
                                           const geom::PrecisionModel& newPM );
 

--- a/src/geom/Geometry.cpp
+++ b/src/geom/Geometry.cpp
@@ -116,6 +116,7 @@ Geometry::Geometry(const GeometryFactory *newFactory)
 		factory = GeometryFactory::getDefaultInstance();
 	} 
 	SRID=factory->getSRID();
+	factory->addChild(this);
 }
 
 Geometry::Geometry(const Geometry &geom)
@@ -132,6 +133,7 @@ Geometry::Geometry(const Geometry &geom)
 	//envelope(new Envelope(*(geom.envelope.get())));
 	//SRID=geom.getSRID();
 	//userData=NULL;
+	factory->addChild(this);
 }
 
 bool
@@ -808,7 +810,7 @@ Geometry::getLength() const
 
 Geometry::~Geometry()
 {
-	//delete envelope;
+	factory->delChild(this);
 }
 
 bool

--- a/src/geom/GeometryFactory.cpp
+++ b/src/geom/GeometryFactory.cpp
@@ -78,7 +78,7 @@ public:
 
 
 
-/*public*/
+/*protected*/
 GeometryFactory::GeometryFactory()
 	:
 	precisionModel(new PrecisionModel()),
@@ -92,7 +92,11 @@ GeometryFactory::GeometryFactory()
 #endif
 }
 
-/*public*/
+/*public static*/
+GeometryFactory::unique_ptr
+GeometryFactory::create() { return GeometryFactory::unique_ptr(new GeometryFactory()); }
+
+/*protected*/
 GeometryFactory::GeometryFactory(const PrecisionModel* pm, int newSRID,
 		CoordinateSequenceFactory* nCoordinateSequenceFactory)
 	:
@@ -115,7 +119,17 @@ GeometryFactory::GeometryFactory(const PrecisionModel* pm, int newSRID,
 	}
 }
 
-/*public*/
+/*public static*/
+GeometryFactory::unique_ptr
+GeometryFactory::create(const PrecisionModel* pm, int newSRID,
+		CoordinateSequenceFactory* nCoordinateSequenceFactory)
+{
+  return GeometryFactory::unique_ptr(
+    new GeometryFactory(pm, newSRID, nCoordinateSequenceFactory)
+  );
+}
+
+/*protected*/
 GeometryFactory::GeometryFactory(
 		CoordinateSequenceFactory* nCoordinateSequenceFactory)
 	:
@@ -133,7 +147,17 @@ GeometryFactory::GeometryFactory(
 	}
 }
 
-/*public*/
+/*public static*/
+GeometryFactory::unique_ptr
+GeometryFactory::create(
+		CoordinateSequenceFactory* nCoordinateSequenceFactory)
+{
+  return GeometryFactory::unique_ptr(
+    new GeometryFactory(nCoordinateSequenceFactory)
+  );
+}
+
+/*protected*/
 GeometryFactory::GeometryFactory(const PrecisionModel *pm)
 	:
 	SRID(0),
@@ -150,7 +174,16 @@ GeometryFactory::GeometryFactory(const PrecisionModel *pm)
 	}
 }
 
-/*public*/
+/*public static*/
+GeometryFactory::unique_ptr
+GeometryFactory::create(const PrecisionModel *pm)
+{
+  return GeometryFactory::unique_ptr(
+    new GeometryFactory(pm)
+  );
+}
+
+/*protected*/
 GeometryFactory::GeometryFactory(const PrecisionModel* pm, int newSRID)
 	:
 	SRID(newSRID),
@@ -167,7 +200,16 @@ GeometryFactory::GeometryFactory(const PrecisionModel* pm, int newSRID)
 	}
 }
 
-/*public*/
+/*public static*/
+GeometryFactory::unique_ptr
+GeometryFactory::create(const PrecisionModel* pm, int newSRID)
+{
+  return GeometryFactory::unique_ptr(
+    new GeometryFactory(pm, newSRID)
+  );
+}
+
+/*protected*/
 GeometryFactory::GeometryFactory(const GeometryFactory &gf)
 {
 	assert(gf.precisionModel);
@@ -178,7 +220,16 @@ GeometryFactory::GeometryFactory(const GeometryFactory &gf)
   _geometryCount=0;
 }
 
-/*public*/
+/*public static*/
+GeometryFactory::unique_ptr
+GeometryFactory::create(const GeometryFactory &gf)
+{
+  return GeometryFactory::unique_ptr(
+    new GeometryFactory(gf)
+  );
+}
+
+/*public virtual*/
 GeometryFactory::~GeometryFactory(){
 #if GEOS_DEBUG
 	std::cerr << "GEOS_DEBUG: GeometryFactory["<<this<<"]::~GeometryFactory()" << std::endl;
@@ -754,7 +805,7 @@ GeometryFactory::delChild(const Geometry *) const
 }
 
 void
-GeometryFactory::autoDestroy()
+GeometryFactory::destroy()
 {
 	assert(!_autoDestroy); // don't call me twice !
 	_autoDestroy = true;

--- a/src/operation/valid/ConnectedInteriorTester.cpp
+++ b/src/operation/valid/ConnectedInteriorTester.cpp
@@ -69,7 +69,7 @@ namespace operation { // geos.operation
 namespace valid { // geos.operation.valid
 
 ConnectedInteriorTester::ConnectedInteriorTester(GeometryGraph &newGeomGraph):
-	geometryFactory(new GeometryFactory()),
+	geometryFactory(GeometryFactory::create()),
 	geomGraph(newGeomGraph),
 	disconnectedRingcoord()
 {
@@ -77,7 +77,6 @@ ConnectedInteriorTester::ConnectedInteriorTester(GeometryGraph &newGeomGraph):
 
 ConnectedInteriorTester::~ConnectedInteriorTester()
 {
-	delete geometryFactory;
 }
 
 Coordinate&
@@ -219,7 +218,7 @@ ConnectedInteriorTester::buildEdgeRings(std::vector<EdgeEnd*> *dirEdges,
 		if(de->isInResult() && de->getEdgeRing()==NULL)
 		{
 			MaximalEdgeRing* er = new MaximalEdgeRing(de,
-			                                   geometryFactory);
+			                                   geometryFactory.get());
 			// We track MaximalEdgeRings allocations
 			// using the private maximalEdgeRings vector
 			maximalEdgeRings.push_back(er);

--- a/src/precision/GeometryPrecisionReducer.cpp
+++ b/src/precision/GeometryPrecisionReducer.cpp
@@ -107,7 +107,7 @@ GeometryPrecisionReducer::fixPolygonalTopology(const geom::Geometry& geom )
    * geometry to targetPM, buffer in that model, then flip back
    */
   auto_ptr<Geometry> tmp;
-  auto_ptr<GeometryFactory> tmpFactory;
+  GeometryFactory::unique_ptr tmpFactory;
 
   const Geometry* geomToBuffer = &geom;
 
@@ -128,12 +128,12 @@ GeometryPrecisionReducer::fixPolygonalTopology(const geom::Geometry& geom )
 }
 
 /* private */
-auto_ptr<GeometryFactory>
+GeometryFactory::unique_ptr
 GeometryPrecisionReducer::createFactory( const GeometryFactory& oldGF,
                                          const PrecisionModel& newPM )
 {
-  auto_ptr<GeometryFactory> newFactory(
-    new GeometryFactory(&newPM,
+  GeometryFactory::unique_ptr newFactory(
+    GeometryFactory::create(&newPM,
                         oldGF.getSRID(),
                         const_cast<CoordinateSequenceFactory*>(oldGF.getCoordinateSequenceFactory()))
   );

--- a/tests/bigtest/TestSweepLineSpeed.cpp
+++ b/tests/bigtest/TestSweepLineSpeed.cpp
@@ -53,7 +53,8 @@ void run(int nPts, GeometryFactory *fact) {
 
 int main(int /* argc */, char** /* argv[] */) {
 
-	GeometryFactory *fact=new GeometryFactory();
+	GeometryFactory::unique_ptr factptr = GeometryFactory::create();
+	GeometryFactory* fact = factptr.get();
 
 	run(1000,fact);
 	run(2000,fact);
@@ -70,8 +71,6 @@ int main(int /* argc */, char** /* argv[] */) {
 //	_CrtDumpMemoryLeaks();
 
 	cout << "Done" << endl;
-
-    // FIXME - mloskot: Who's gonna to eat the 'fact'? Mr. Leak!
 
 	return 0;
 }

--- a/tests/bigtest/bug234.cpp
+++ b/tests/bigtest/bug234.cpp
@@ -12,7 +12,7 @@ using namespace geos::geom;
 using namespace std;
 
 int main() {
- GeometryFactory factory;
+ GeometryFactory::unique_ptr factory = GeometryFactory::create();
 
  vector< Geometry * > *polys1 = new vector<Geometry*>();
  vector< Geometry * > *polys2 = new vector<Geometry*>();
@@ -24,8 +24,8 @@ int main() {
  coords1.add(Coordinate(5, 5));
  coords1.add(Coordinate(5, 1));
  coords1.add(Coordinate(1, 1));
- holes1->push_back( factory.createLinearRing() );
- polys1->push_back( factory.createPolygon(factory.createLinearRing(coords1), holes1) );
+ holes1->push_back( factory->createLinearRing() );
+ polys1->push_back( factory->createPolygon(factory->createLinearRing(coords1), holes1) );
 
  CoordinateArraySequence coords2;
  coords2.add(Coordinate(3, 3));
@@ -33,10 +33,10 @@ int main() {
  coords2.add(Coordinate(4, 4));
  coords2.add(Coordinate(4, 3));
  coords2.add(Coordinate(3, 3));
- polys2->push_back( factory.createPolygon(factory.createLinearRing(coords2), new vector<Geometry*>) );
+ polys2->push_back( factory->createPolygon(factory->createLinearRing(coords2), new vector<Geometry*>) );
 
- MultiPolygon *mpoly1 = factory.createMultiPolygon(polys1);
- MultiPolygon *mpoly2 = factory.createMultiPolygon(polys2);
+ MultiPolygon *mpoly1 = factory->createMultiPolygon(polys1);
+ MultiPolygon *mpoly2 = factory->createMultiPolygon(polys2);
 
  cout << "      Mpoly1: " << mpoly1->toString() << endl;
  cout << "      Mpoly2: " << mpoly2->toString() << endl;

--- a/tests/perf/operation/buffer/IteratedBufferStressTest.cpp
+++ b/tests/perf/operation/buffer/IteratedBufferStressTest.cpp
@@ -73,8 +73,8 @@ int
 main()
 {
 	PrecisionModel pm;
-	GeometryFactory gf(&pm);
-	WKTReader rdr(&gf);
+	GeometryFactory::unique_ptr gf = GeometryFactory::create(&pm);
+	WKTReader rdr(gf.get());
 
 	string inputWKT =
         "POLYGON ((110 320, 190 220, 60 200, 180 120, 120 40, 290 150, 410 40, 410 230, 500 340, 320 310, 260 370, 220 310, 110 320), (220 260, 250 180, 290 220, 360 150, 350 250, 260 280, 220 260))";

--- a/tests/perf/operation/predicate/RectangleIntersectsPerfTest.cpp
+++ b/tests/perf/operation/predicate/RectangleIntersectsPerfTest.cpp
@@ -41,7 +41,7 @@ public:
   RectangleIntersectsPerfTest()
     :
     pm(),
-    fact(&pm, 0)
+    fact(GeometryFactory::create(&pm, 0))
   {}
 
   void test(int nPts)
@@ -78,7 +78,7 @@ private:
   static const int NUM_LINE_PTS = 1000;
 
   PrecisionModel pm;
-  GeometryFactory fact;
+  GeometryFactory::unique_ptr fact;
 
   void testRectangles(const Geometry& target, int nRect, double rectSize)
   {
@@ -122,7 +122,7 @@ private:
         Envelope envRect(
             baseX, baseX + dx,
             baseY, baseY + dy);
-        Geometry* rect = fact.toGeometry(&envRect);
+        Geometry* rect = fact->toGeometry(&envRect);
         rectList.push_back(rect);
       }
     }
@@ -133,7 +133,7 @@ private:
   {
       using geos::geom::util::SineStarFactory;
 
-      SineStarFactory gsf(&fact);
+      SineStarFactory gsf(fact.get());
       gsf.setCentre(origin);
       gsf.setSize(size);
       gsf.setNumPoints(nPts);

--- a/tests/unit/algorithm/ConvexHullTest.cpp
+++ b/tests/unit/algorithm/ConvexHullTest.cpp
@@ -39,21 +39,22 @@ namespace tut
 		// Typedefs used as short names by test cases
         typedef std::auto_ptr<geos::geom::Geometry> GeometryAPtr;
         typedef std::auto_ptr<geos::geom::LineString> LineStringAPtr;
+        typedef geos::geom::GeometryFactory GeometryFactory;
 
         GeometryPtr geom_;
         geos::geom::PrecisionModel pm_;
-        geos::geom::GeometryFactory factory_;
+        geos::geom::GeometryFactory::unique_ptr factory_;
         geos::io::WKTReader reader_;
 
         test_convexhull_data()
-			: geom_(0), pm_(1), factory_(&pm_, 0), reader_(&factory_)
+			: geom_(0), pm_(1), factory_(GeometryFactory::create(&pm_, 0)), reader_(factory_.get())
         {
             assert(0 == geom_);
         }
 
         ~test_convexhull_data()
         {
-            factory_.destroyGeometry(geom_);
+            factory_->destroyGeometry(geom_);
             geom_ = 0;
         }
     };

--- a/tests/unit/algorithm/PointLocatorTest.cpp
+++ b/tests/unit/algorithm/PointLocatorTest.cpp
@@ -42,8 +42,8 @@ namespace tut
 	// for the same reason...
 	//
 	static PrecisionModel pm;
-	static GeometryFactory gf(&pm);
-        static geos::io::WKTReader reader(&gf);
+	static GeometryFactory::unique_ptr gf = GeometryFactory::create(&pm);
+	static geos::io::WKTReader reader(gf.get());
 
 	typedef std::auto_ptr<Geometry> GeomPtr;
 

--- a/tests/unit/algorithm/RobustLineIntersectionTest.cpp
+++ b/tests/unit/algorithm/RobustLineIntersectionTest.cpp
@@ -244,14 +244,14 @@ namespace tut
 	test_robustlineintersection_data()
 		:
 		pm(),
-		gf(&pm),
-		reader(&gf)
+		gf(GeometryFactory::create(&pm)),
+		reader(gf.get())
 	{
 	}
 
 	PrecisionModel pm;
-	GeometryFactory gf;
-        geos::io::WKTReader reader;
+	GeometryFactory::unique_ptr gf;
+  geos::io::WKTReader reader;
 
 	};
 

--- a/tests/unit/algorithm/RobustLineIntersectorTest.cpp
+++ b/tests/unit/algorithm/RobustLineIntersectorTest.cpp
@@ -238,13 +238,13 @@ namespace tut
     using geos::geom::GeometryFactory;
     using geos::geom::LineString;
 
-    GeometryFactory factory;
+    GeometryFactory::unique_ptr factory = GeometryFactory::create();
     CoordinateSequence* cs = new CoordinateArraySequence();
     cs->add(p1);
     cs->add(p2);
 
-    GeomPtr l ( factory.createLineString(cs) );
-    GeomPtr p ( factory.createPoint(q) );
+    GeomPtr l ( factory->createLineString(cs) );
+    GeomPtr p ( factory->createPoint(q) );
     ensure(!l->intersects(p.get()));
 
     ensure(!CGAlgorithms::isOnLine(q, cs));
@@ -298,9 +298,10 @@ namespace tut
     template<>
     void object::test<15>()
     {
+        using geos::geom::GeometryFactory;
         geos::geom::PrecisionModel pm(1e+13);
-        geos::geom::GeometryFactory factory(&pm);
-        geos::io::WKBReader reader(factory);
+        GeometryFactory::unique_ptr factory = GeometryFactory::create(&pm);
+        geos::io::WKBReader reader(*factory);
 
         // POINT located between 3rd and 4th vertex of LINESTRING
         // POINT(-23.1094689600055080 50.5195368635957180)

--- a/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
+++ b/tests/unit/algorithm/distance/DiscreteHausdorffDistanceTest.cpp
@@ -41,8 +41,8 @@ namespace tut
 	test_DiscreteHausdorffDistance_data()
 		:
 		pm(),
-		gf(&pm),
-		reader(&gf)
+		gf(GeometryFactory::create(&pm)),
+		reader(gf.get())
 	{}
 
 	static const double TOLERANCE;
@@ -73,8 +73,8 @@ namespace tut
 	}
 
 	PrecisionModel pm;
-	GeometryFactory gf;
-        geos::io::WKTReader reader;
+	GeometryFactory::unique_ptr gf;
+  geos::io::WKTReader reader;
 
 	};
 	const double test_DiscreteHausdorffDistance_data::TOLERANCE = 0.00001;

--- a/tests/unit/capi/GEOSPreparedGeometryTest.cpp
+++ b/tests/unit/capi/GEOSPreparedGeometryTest.cpp
@@ -219,8 +219,8 @@ namespace tut
     void object::test<8>()
     {
         geos::geom::PrecisionModel pm(1e+13);
-        geos::geom::GeometryFactory factory(&pm);
-        geos::io::WKBReader reader(factory);
+        geos::geom::GeometryFactory *factory = new geos::geom::GeometryFactory(&pm);
+        geos::io::WKBReader reader(*factory);
 
         // POINT located between 3rd and 4th vertex of LINESTRING
         // POINT(-23.1094689600055080 50.5195368635957180)
@@ -236,6 +236,8 @@ namespace tut
         ensure(0 != prepGeom1_);
         int ret = GEOSPreparedIntersects(prepGeom1_, geom2_);
         ensure_equals(ret, 1);
+
+        factory->autoDestroy();
     }
 
     // Test PreparedIntersects: point on vertex (default FLOAT PM)

--- a/tests/unit/capi/GEOSPreparedGeometryTest.cpp
+++ b/tests/unit/capi/GEOSPreparedGeometryTest.cpp
@@ -219,7 +219,7 @@ namespace tut
     void object::test<8>()
     {
         geos::geom::PrecisionModel pm(1e+13);
-        geos::geom::GeometryFactory *factory = new geos::geom::GeometryFactory(&pm);
+        geos::geom::GeometryFactory::unique_ptr factory = geos::geom::GeometryFactory::create(&pm);
         geos::io::WKBReader reader(*factory);
 
         // POINT located between 3rd and 4th vertex of LINESTRING
@@ -236,8 +236,6 @@ namespace tut
         ensure(0 != prepGeom1_);
         int ret = GEOSPreparedIntersects(prepGeom1_, geom2_);
         ensure_equals(ret, 1);
-
-        factory->autoDestroy();
     }
 
     // Test PreparedIntersects: point on vertex (default FLOAT PM)

--- a/tests/unit/geom/Geometry/clone.cpp
+++ b/tests/unit/geom/Geometry/clone.cpp
@@ -21,11 +21,13 @@ namespace tut {
 struct test_geometry_clone_data
 {
 	typedef std::auto_ptr<geos::geom::Geometry> GeomAutoPtr;
-	geos::geom::GeometryFactory factory;
+	typedef geos::geom::GeometryFactory GeometryFactory;
+	GeometryFactory::unique_ptr factory;
 	geos::io::WKTReader reader;
 
 	test_geometry_clone_data()
-	    : reader(&factory)
+	    : factory(GeometryFactory::create())
+	    , reader(factory.get())
 	{}
 };
 

--- a/tests/unit/geom/Geometry/coversTest.cpp
+++ b/tests/unit/geom/Geometry/coversTest.cpp
@@ -21,11 +21,14 @@ namespace tut {
 struct test_contains_data
 {
 	typedef std::auto_ptr<geos::geom::Geometry> GeomAutoPtr;
-	geos::geom::GeometryFactory factory;
+	typedef geos::geom::GeometryFactory GeometryFactory;
+
+	geos::geom::GeometryFactory::unique_ptr factory;
 	geos::io::WKTReader reader;
 
 	test_contains_data()
-	    : reader(&factory)
+	    : factory(GeometryFactory::create())
+	    , reader(factory.get())
 	{}
 };
 

--- a/tests/unit/geom/Geometry/equalsTest.cpp
+++ b/tests/unit/geom/Geometry/equalsTest.cpp
@@ -21,11 +21,10 @@ namespace tut {
 struct test_equals_data
 {
 	typedef std::auto_ptr<geos::geom::Geometry> GeomAutoPtr;
-	geos::geom::GeometryFactory factory;
 	geos::io::WKTReader reader;
 
 	test_equals_data()
-	    : reader(&factory)
+	    : reader()
 	{}
 };
 

--- a/tests/unit/geom/Geometry/isRectangleTest.cpp
+++ b/tests/unit/geom/Geometry/isRectangleTest.cpp
@@ -4,7 +4,6 @@
 // tut
 #include <tut.hpp>
 // geos
-#include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/Polygon.h>
 #include <geos/io/WKTReader.h>
@@ -19,11 +18,9 @@ namespace tut
 
     struct test_isrectangle_data
     {
-        geos::geom::GeometryFactory factory;
         geos::io::WKTReader reader;
 
         test_isrectangle_data()
-            : reader(&factory)
         {}
     };
 

--- a/tests/unit/geom/Geometry/normalize.cpp
+++ b/tests/unit/geom/Geometry/normalize.cpp
@@ -4,7 +4,6 @@
 // tut
 #include <tut.hpp>
 // geos
-#include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/Polygon.h>
 #include <geos/io/WKTReader.h>
@@ -23,12 +22,11 @@ namespace tut {
 struct test_geometry_normalize_data
 {
   typedef std::auto_ptr<geos::geom::Geometry> GeomAutoPtr;
-  geos::geom::GeometryFactory factory;
   geos::io::WKTReader reader;
   geos::io::WKTWriter writer;
 
   test_geometry_normalize_data()
-      : reader(&factory), writer()
+      : reader(), writer()
   {
     writer.setTrim(true);
   }

--- a/tests/unit/geom/GeometryFactoryTest.cpp
+++ b/tests/unit/geom/GeometryFactoryTest.cpp
@@ -54,11 +54,13 @@ namespace tut
 
         const int srid_;
         geos::geom::PrecisionModel pm_;
-        geos::geom::GeometryFactory factory_;
+        geos::geom::GeometryFactory::unique_ptr factory_;
         geos::io::WKTReader reader_;
 
         test_geometryfactory_data()
-            : x_(5), y_(10), z_(15), srid_(666), pm_(1.0), factory_(&pm_, srid_), reader_(&factory_)
+            : x_(5), y_(10), z_(15), srid_(666), pm_(1.0),
+factory_(geos::geom::GeometryFactory::create(&pm_, srid_)),
+reader_(factory_.get())
         {}
     private:
         // Declare type as noncopyable
@@ -80,18 +82,19 @@ namespace tut
 	template<>
 	void object::test<1>()
 	{
-		geos::geom::GeometryFactory gf;
+		using geos::geom::GeometryFactory;
+		GeometryFactory::unique_ptr gf = GeometryFactory::create();
 
-		ensure_equals( gf.getSRID(), 0 );
-		ensure_equals( gf.getPrecisionModel()->getType(), geos::geom::PrecisionModel::FLOATING );
+		ensure_equals( gf->getSRID(), 0 );
+		ensure_equals( gf->getPrecisionModel()->getType(), geos::geom::PrecisionModel::FLOATING );
 
-		geos::geom::Geometry* geo = gf.createEmptyGeometry();
+		geos::geom::Geometry* geo = gf->createEmptyGeometry();
 		ensure( "createEmptyGeometry() returned null pointer.", geo != 0 );
-		ensure_equals( geo->getSRID() , gf.getSRID() );
+		ensure_equals( geo->getSRID() , gf->getSRID() );
 		ensure_equals( geo->getPrecisionModel()->getType(), geos::geom::PrecisionModel::FLOATING );
 		
 		// FREE MEMORY
-		gf.destroyGeometry(geo);
+		gf->destroyGeometry(geo);
 	}
 
 	// Test of user's constructor
@@ -107,20 +110,20 @@ namespace tut
 
 		{
 			PrecisionModel pm(1.0);
-			GeometryFactory gf(&pm, srid_, &csf);
+			GeometryFactory::unique_ptr gf = GeometryFactory::create(&pm, srid_, &csf);
 
-			ensure_equals( gf.getSRID(), srid_ );
-			ensure_equals( gf.getPrecisionModel()->getType(), geos::geom::PrecisionModel::FIXED );
+			ensure_equals( gf->getSRID(), srid_ );
+			ensure_equals( gf->getPrecisionModel()->getType(), geos::geom::PrecisionModel::FIXED );
 
-			ensure_equals( &csf, gf.getCoordinateSequenceFactory() );
+			ensure_equals( &csf, gf->getCoordinateSequenceFactory() );
 
-			GeometryPtr geo = gf.createEmptyGeometry();
+			GeometryPtr geo = gf->createEmptyGeometry();
 			ensure( "createEmptyGeometry() returned null pointer.", geo != 0 );
-			ensure_equals( geo->getSRID() , gf.getSRID() );
+			ensure_equals( geo->getSRID() , gf->getSRID() );
 			ensure_equals( geo->getPrecisionModel()->getType(), geos::geom::PrecisionModel::FIXED );
 			
 			// FREE MEMORY
-			gf.destroyGeometry(geo);
+			gf->destroyGeometry(geo);
 		}
 		// csf lifetime must exceed lifetime of the GeometryFactory instance
 
@@ -137,18 +140,18 @@ namespace tut
 		CoordinateArraySequenceFactory csf;
 
 		{
-			GeometryFactory gf(&csf);
+			GeometryFactory::unique_ptr gf = GeometryFactory::create(&csf);
 
-			ensure_equals( gf.getSRID(), 0 );
-			ensure_equals( gf.getPrecisionModel()->getType(), geos::geom::PrecisionModel::FLOATING );
+			ensure_equals( gf->getSRID(), 0 );
+			ensure_equals( gf->getPrecisionModel()->getType(), geos::geom::PrecisionModel::FLOATING );
 
-			GeometryPtr geo = gf.createEmptyGeometry();
+			GeometryPtr geo = gf->createEmptyGeometry();
 			ensure( "createEmptyGeometry() returned null pointer.", geo != 0 );
-			ensure_equals( geo->getSRID() , gf.getSRID() );
+			ensure_equals( geo->getSRID() , gf->getSRID() );
 			ensure_equals( geo->getPrecisionModel()->getType(), geos::geom::PrecisionModel::FLOATING );
 			
 			// FREE MEMORY
-			gf.destroyGeometry(geo);
+			gf->destroyGeometry(geo);
 		}
 		// csf lifetime must exceed lifetime of the GeometryFactory instance
 	}
@@ -159,20 +162,21 @@ namespace tut
 	void object::test<4>()
 	{
 		using geos::geom::PrecisionModel;
+		using geos::geom::GeometryFactory;
 
 		PrecisionModel pm(PrecisionModel::FIXED);
-		geos::geom::GeometryFactory gf(&pm);
+		GeometryFactory::unique_ptr gf(GeometryFactory::create(&pm));
 
-		ensure_equals( gf.getSRID(), 0 );
-		ensure_equals( gf.getPrecisionModel()->getType(), PrecisionModel::FIXED );
+		ensure_equals( gf->getSRID(), 0 );
+		ensure_equals( gf->getPrecisionModel()->getType(), PrecisionModel::FIXED );
 
-		GeometryPtr geo = gf.createEmptyGeometry();
+		GeometryPtr geo = gf->createEmptyGeometry();
 		ensure( "createEmptyGeometry() returned null pointer.", geo != 0 );
-		ensure_equals( geo->getSRID() , gf.getSRID() );
+		ensure_equals( geo->getSRID() , gf->getSRID() );
 		ensure_equals( geo->getPrecisionModel()->getType(), PrecisionModel::FIXED );
 		
 		// FREE MEMORY
-		gf.destroyGeometry(geo);
+		gf->destroyGeometry(geo);
 	}
 
 	// Test of user's constructor
@@ -181,20 +185,21 @@ namespace tut
 	void object::test<5>()
 	{
 		using geos::geom::PrecisionModel;
+		using geos::geom::GeometryFactory;
 
 		PrecisionModel pm(PrecisionModel::FIXED);
-		geos::geom::GeometryFactory gf(&pm, srid_);
+		GeometryFactory::unique_ptr gf(GeometryFactory::create(&pm, srid_));
 
-		ensure_equals( gf.getSRID(), srid_ );
-		ensure_equals( gf.getPrecisionModel()->getType(), PrecisionModel::FIXED );
+		ensure_equals( gf->getSRID(), srid_ );
+		ensure_equals( gf->getPrecisionModel()->getType(), PrecisionModel::FIXED );
 
-		GeometryPtr geo = gf.createEmptyGeometry();
+		GeometryPtr geo = gf->createEmptyGeometry();
 		ensure( "createEmptyGeometry() returned null pointer.", geo != 0 );
-		ensure_equals( geo->getSRID() , gf.getSRID() );
+		ensure_equals( geo->getSRID() , gf->getSRID() );
 		ensure_equals( geo->getPrecisionModel()->getType(), PrecisionModel::FIXED );
 		
 		// FREE MEMORY
-		gf.destroyGeometry(geo);
+		gf->destroyGeometry(geo);
 	}
 
 	// Test of copy constructor
@@ -202,10 +207,11 @@ namespace tut
 	template<>
 	void object::test<6>()
 	{
-		geos::geom::GeometryFactory gf(factory_);
+		using geos::geom::GeometryFactory;
+		GeometryFactory::unique_ptr gf(GeometryFactory::create(*factory_));
 
-		ensure_equals( factory_.getSRID(), gf.getSRID() );
-		ensure_equals( factory_.getPrecisionModel()->getType(), gf.getPrecisionModel()->getType() );
+		ensure_equals( factory_->getSRID(), gf->getSRID() );
+		ensure_equals( factory_->getPrecisionModel()->getType(), gf->getPrecisionModel()->getType() );
 	}
 
 	// Test of createEmptyGeometry() const
@@ -213,7 +219,7 @@ namespace tut
 	template<>
 	void object::test<7>()
 	{
-		GeometryPtr geo = factory_.createEmptyGeometry();
+		GeometryPtr geo = factory_->createEmptyGeometry();
 
 		ensure( "createEmptyGeometry() returned null pointer.", geo != 0 );
 		ensure( "createEmptyGeometry() returned non-empty geometry.", geo->isEmpty() );
@@ -229,7 +235,7 @@ namespace tut
 		*/
 
 		// FREE MEMORY
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of createPoint() const
@@ -237,7 +243,7 @@ namespace tut
 	template<>
 	void object::test<8>()
 	{
-		PointPtr pt = factory_.createPoint();
+		PointPtr pt = factory_->createPoint();
 
 		ensure( "createPoint() returned null pointer.", pt != 0 );
 		ensure( "createPoint() returned non-empty point.", pt->isEmpty() );
@@ -250,17 +256,17 @@ namespace tut
 		geo = pt->getEnvelope();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->getBoundary();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->convexHull();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( pt->getGeometryTypeId(), geos::geom::GEOS_POINT );
 		ensure_equals( pt->getDimension(), geos::geom::Dimension::P );
@@ -270,7 +276,7 @@ namespace tut
 		ensure_equals( pt->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(pt);
+		factory_->destroyGeometry(pt);
 	}
 
 	// Test of createPoint(const Coordinate &coordinate) const
@@ -280,7 +286,7 @@ namespace tut
 	{
 		geos::geom::Coordinate coord(x_, y_, z_);
 
-		PointPtr pt = factory_.createPoint(coord);
+		PointPtr pt = factory_->createPoint(coord);
 
 		ensure( "createPoint() returned null pointer.", pt != 0 );
 		ensure( "createPoint() returned empty point.", !pt->isEmpty() );
@@ -298,22 +304,22 @@ namespace tut
 		geo = pt->getEnvelope();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->getCentroid();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->getBoundary();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->convexHull();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( pt->getGeometryTypeId(), geos::geom::GEOS_POINT );
 		ensure_equals( pt->getDimension(), geos::geom::Dimension::P );
@@ -323,7 +329,7 @@ namespace tut
 		ensure_equals( pt->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(pt);
+		factory_->destroyGeometry(pt);
 	}
 
 	// Test of createPoint(CoordinateSequence *coordinates) const
@@ -338,7 +344,7 @@ namespace tut
 		ensure( "sequence is null pointer.", sequence != 0 );
 		sequence->add(coord);
 
-		PointPtr pt = factory_.createPoint(sequence);
+		PointPtr pt = factory_->createPoint(sequence);
 
 		ensure( "createPoint() returned null pointer.", pt != 0 );
 		ensure( "createPoint() returned empty point.", !pt->isEmpty() );
@@ -356,22 +362,22 @@ namespace tut
 		geo = pt->getEnvelope();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->getCentroid();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->getBoundary();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->convexHull();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( pt->getGeometryTypeId(), geos::geom::GEOS_POINT );
 		ensure_equals( pt->getDimension(), geos::geom::Dimension::P );
@@ -381,7 +387,7 @@ namespace tut
 		ensure_equals( pt->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(pt);
+		factory_->destroyGeometry(pt);
 	}
 
 	// Test of createPoint(const CoordinateSequence &coordinates) const
@@ -394,7 +400,7 @@ namespace tut
 		geos::geom::CoordinateArraySequence sequence;
 		sequence.add(coord);
 
-		PointPtr pt = factory_.createPoint(sequence);
+		PointPtr pt = factory_->createPoint(sequence);
 
 		ensure( "createPoint() returned null pointer.", pt != 0 );
 		ensure( "createPoint() returned empty point.", !pt->isEmpty() );
@@ -412,22 +418,22 @@ namespace tut
 		geo = pt->getEnvelope();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->getCentroid();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->getBoundary();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = pt->convexHull();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( pt->getGeometryTypeId(), geos::geom::GEOS_POINT );
 		ensure_equals( pt->getDimension(), geos::geom::Dimension::P );
@@ -437,7 +443,7 @@ namespace tut
 		ensure_equals( pt->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(pt);
+		factory_->destroyGeometry(pt);
 	}
 
 	// Test of createLinearRing() const
@@ -445,7 +451,7 @@ namespace tut
 	template<>
 	void object::test<12>()
 	{
-		LinearRingPtr lr = factory_.createLinearRing();
+		LinearRingPtr lr = factory_->createLinearRing();
 
 		ensure( "createLinearRing() returned null pointer.", lr != 0 );
 		ensure( "createLinearRing() returned non-empty point.", lr->isEmpty() );
@@ -470,7 +476,7 @@ namespace tut
 		ensure_equals( lr->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(lr);
+		factory_->destroyGeometry(lr);
 	}
 
 	// Test of createLinearRing(CoordinateSequence* newCoords) const
@@ -483,7 +489,7 @@ namespace tut
 		ensure( coords != 0 );
 		ensure_equals( coords->getSize(), size );
 
-		LinearRingPtr lr = factory_.createLinearRing(coords);
+		LinearRingPtr lr = factory_->createLinearRing(coords);
 		ensure( "createLinearRing() returned null pointer.", lr != 0 );
 		ensure( "createLinearRing() returned empty point.", !lr->isEmpty() );
 		ensure( lr->isSimple() );
@@ -500,7 +506,7 @@ namespace tut
 		ensure_equals( lr->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(lr);	
+		factory_->destroyGeometry(lr);	
 	}
 
 	// Test of createLinearRing(const CoordinateSequence& coordinates) const
@@ -512,7 +518,7 @@ namespace tut
 		geos::geom::CoordinateArraySequence coords(size);
 		ensure_equals( coords.getSize(), size );
 
-		LinearRingPtr lr = factory_.createLinearRing(coords);
+		LinearRingPtr lr = factory_->createLinearRing(coords);
 		ensure( "createLinearRing() returned empty point.", !lr->isEmpty() );
 		ensure_equals( lr->getNumPoints(), size );
 		ensure( lr->isSimple() );
@@ -526,7 +532,7 @@ namespace tut
 		ensure_equals( lr->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(lr);
+		factory_->destroyGeometry(lr);
 	}
 
 	// Test of createLineString() const
@@ -534,7 +540,7 @@ namespace tut
 	template<>
 	void object::test<15>()
 	{
-		LineStringPtr line = factory_.createLineString();
+		LineStringPtr line = factory_->createLineString();
 		
 		ensure( "createLineString() returned null pointer.", line != 0 );
 		ensure( "createLineString() returned non-empty point.", line->isEmpty() );
@@ -550,17 +556,17 @@ namespace tut
 		geo = line->getEnvelope();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = line->getBoundary();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = line->convexHull();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( line->getGeometryTypeId(), geos::geom::GEOS_LINESTRING );
 		ensure_equals( line->getDimension(), geos::geom::Dimension::L );
@@ -570,7 +576,7 @@ namespace tut
 		ensure_equals( line->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(line);
+		factory_->destroyGeometry(line);
 	}
 
 	// Test of createLineString(CoordinateSequence* coordinates) const
@@ -583,7 +589,7 @@ namespace tut
 		ensure( coords != 0 );
 		ensure_equals( coords->getSize(), size );
 
-		LineStringPtr line = factory_.createLineString(coords);
+		LineStringPtr line = factory_->createLineString(coords);
 		ensure( "createLineString() returned null pointer.", line != 0 );
 		ensure( "createLineString() returned empty point.", !line->isEmpty() );
 		ensure( line->isSimple() );
@@ -600,7 +606,7 @@ namespace tut
 		ensure_equals( line->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(line);	
+		factory_->destroyGeometry(line);	
 	}
 
 	// Test of createLineString(const CoordinateSequence& coordinates) const
@@ -612,7 +618,7 @@ namespace tut
 		geos::geom::CoordinateArraySequence coords(size);
 		ensure_equals( coords.getSize(), size );
 
-		LineStringPtr line = factory_.createLineString(coords);
+		LineStringPtr line = factory_->createLineString(coords);
 		ensure( "createLineString() returned empty point.", !line->isEmpty() );
 		ensure_equals( line->getNumPoints(), size );
 		ensure( line->isSimple() );
@@ -626,14 +632,14 @@ namespace tut
 		ensure_equals( line->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(line);
+		factory_->destroyGeometry(line);
 	}
 	// Test of createPolygon() const
 	template<>
 	template<>
 	void object::test<18>()
 	{
-		PolygonPtr poly = factory_.createPolygon();
+		PolygonPtr poly = factory_->createPolygon();
 
 		ensure( "createPolygon() returned null pointer.", poly != 0 );
 		ensure( "createPolygon() returned non-empty point.", poly->isEmpty() );
@@ -651,17 +657,17 @@ namespace tut
 		//geo = poly->getEnvelope();
 		//ensure( geo != 0 );
 		//ensure( geo->isEmpty() );
-		//factory_.destroyGeometry(geo);
+		//factory_->destroyGeometry(geo);
 
 		geo = poly->getBoundary();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = poly->convexHull();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( poly->getGeometryTypeId(), geos::geom::GEOS_POLYGON );
 		ensure_equals( poly->getDimension(), geos::geom::Dimension::A );
@@ -671,7 +677,7 @@ namespace tut
 		ensure_equals( poly->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(poly);
+		factory_->destroyGeometry(poly);
 	}
 
 	// Test of createPolygon(LinearRing* shell, std::vector<Geometry*>* holes) const
@@ -695,7 +701,7 @@ namespace tut
 		ensure_equals( coords->getSize(), size );
 
 		// Create exterior ring
-		LinearRingPtr exterior = factory_.createLinearRing(coords);
+		LinearRingPtr exterior = factory_->createLinearRing(coords);
 		ensure( "createLinearRing returned null pointer.", exterior != 0 );
 		ensure( "createLinearRing() returned empty point.", !exterior->isEmpty() );
 		ensure( exterior->isSimple() );
@@ -707,7 +713,7 @@ namespace tut
 		ensure( exterior->getLength() != 0.0 );
 
 		// Create polygon
-		PolygonPtr poly = factory_.createPolygon(exterior, 0);
+		PolygonPtr poly = factory_->createPolygon(exterior, 0);
 		ensure( "createPolygon returned null pointer.", poly != 0 );
 		ensure( "createPolygon() returned empty point.", !poly->isEmpty() );
 		ensure( poly->isSimple() );
@@ -719,7 +725,7 @@ namespace tut
 		ensure( poly->getLength() != 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(poly);	
+		factory_->destroyGeometry(poly);	
 	}
 
 	// Test of createPolygon(const LinearRing& shell, const std::vector<Geometry*>& holes) const
@@ -744,7 +750,7 @@ namespace tut
 		ensure_equals( coords->getSize(), exteriorSize );
 
 		// Create exterior ring
-		LinearRingPtr exterior = factory_.createLinearRing(coords);
+		LinearRingPtr exterior = factory_->createLinearRing(coords);
 		ensure( "createLinearRing returned null pointer.", exterior != 0 );
 		ensure( "createLinearRing() returned empty point.", !exterior->isEmpty() );
 		ensure( exterior->isSimple() );
@@ -769,7 +775,7 @@ namespace tut
 		holes.push_back(hole);
 
 		// Create polygon using copy ctor
-		PolygonPtr poly = factory_.createPolygon((*exterior), holes);
+		PolygonPtr poly = factory_->createPolygon((*exterior), holes);
 		ensure( "createPolygon returned null pointer.", poly != 0 );
 		ensure( "createPolygon() returned empty point.", !poly->isEmpty() );
 		ensure( poly->isSimple() );
@@ -791,8 +797,8 @@ namespace tut
 		}
 		holes.clear();
 
-		factory_.destroyGeometry(exterior);
-		factory_.destroyGeometry(poly);
+		factory_->destroyGeometry(exterior);
+		factory_->destroyGeometry(poly);
 	}
 
 	// Test of createGeometryCollection() const
@@ -800,7 +806,7 @@ namespace tut
 	template<>
 	void object::test<21>()
 	{
-		GeometryColPtr col = factory_.createGeometryCollection();
+		GeometryColPtr col = factory_->createGeometryCollection();
 
 		ensure( "createGeometryCollection() returned null pointer.", col != 0 );
 		ensure( col->isEmpty() );
@@ -826,7 +832,7 @@ namespace tut
 		ensure_equals( col->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(col);
+		factory_->destroyGeometry(col);
 	}
 
 	// Test of createGeometryCollection(std::vector<Geometry*>* newGeoms) const
@@ -841,7 +847,7 @@ namespace tut
 
 		// Add single point
 		Coordinate coord(x_, y_, z_);
-		GeometryPtr point = factory_.createPoint(coord);
+		GeometryPtr point = factory_->createPoint(coord);
 		ensure( point != 0 );
 		vec->push_back(point);
 
@@ -852,17 +858,17 @@ namespace tut
 		coords->setAt(Coordinate(5, 5), 1);
 		coords->setAt(Coordinate(10, 5), 2);
 		ensure_equals( coords->getSize(), 3u );
-		GeometryPtr line = factory_.createLineString(coords);
+		GeometryPtr line = factory_->createLineString(coords);
 		vec->push_back(line);
 
 		// Create geometry collection
-		GeometryColPtr col = factory_.createGeometryCollection(vec);
+		GeometryColPtr col = factory_->createGeometryCollection(vec);
 		ensure( coords != 0 );
 		ensure_equals( col->getGeometryTypeId(), geos::geom::GEOS_GEOMETRYCOLLECTION );
 		ensure_equals( col->getNumGeometries(), 2u );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(col);
+		factory_->destroyGeometry(col);
 	}
 
 	// Test of createGeometryCollection(const std::vector<Geometry*>& newGeoms) const
@@ -876,29 +882,29 @@ namespace tut
 		std::vector<GeometryPtr> vec;
 
 		GeometryPtr geo = 0;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		// Factory creates copy of the vec collection
-		GeometryColPtr col = factory_.createGeometryCollection(vec);
+		GeometryColPtr col = factory_->createGeometryCollection(vec);
 		ensure( col != 0 );
 		ensure_equals( col->getGeometryTypeId() , geos::geom::GEOS_GEOMETRYCOLLECTION );
 		ensure_equals( col->getNumGeometries() , size );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(col);
+		factory_->destroyGeometry(col);
 		std::vector<GeometryPtr>::const_iterator it;
 		for (it = vec.begin(); it != vec.end(); ++it)
 		{
@@ -911,7 +917,7 @@ namespace tut
 	template<>
 	void object::test<24>()
 	{
-		MultiPointPtr mp = factory_.createMultiPoint();
+		MultiPointPtr mp = factory_->createMultiPoint();
 
 		ensure( "createMultiPoint() returned null pointer.", mp != 0 );
 		ensure( "createMultiPoint() returned non-empty point.", mp->isEmpty() );
@@ -926,17 +932,17 @@ namespace tut
 		//geo = poly->getEnvelope();
 		//ensure( geo != 0 );
 		//ensure( geo->isEmpty() );
-		//factory_.destroyGeometry(geo);
+		//factory_->destroyGeometry(geo);
 
 		geo = mp->getBoundary();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = mp->convexHull();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( mp->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT );
 		ensure_equals( mp->getDimension(), geos::geom::Dimension::P );
@@ -946,7 +952,7 @@ namespace tut
 		ensure_equals( mp->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(mp);
+		factory_->destroyGeometry(mp);
 	}
 
 	// Test of createMultiPoint(std::vector<Geometry*>* newPoints) const
@@ -960,26 +966,26 @@ namespace tut
 		std::vector<GeometryPtr>* vec = new std::vector<GeometryPtr>();
 
 		GeometryPtr geo = 0;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		ensure( geo != 0 );
 		vec->push_back(geo);
 
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		ensure( geo != 0 );
 		vec->push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		ensure( geo != 0 );
 		vec->push_back(geo);
 
 		// Factory creates copy of the vec collection
-		MultiPointPtr mp = factory_.createMultiPoint(vec);
+		MultiPointPtr mp = factory_->createMultiPoint(vec);
 		ensure( mp != 0 );
 		ensure( mp->isValid() );
 		ensure( mp->isSimple() );
@@ -987,7 +993,7 @@ namespace tut
 		ensure_equals( mp->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(mp);
+		factory_->destroyGeometry(mp);
 	}
 
 	// Test of createMultiPoint(const std::vector<Geometry*>& fromPoints) const
@@ -1001,23 +1007,23 @@ namespace tut
 		std::vector<GeometryPtr> vec;
 
 		GeometryPtr geo = 0;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		// Factory creates copy of the vec collection
-		MultiPointPtr mp = factory_.createMultiPoint(vec);
+		MultiPointPtr mp = factory_->createMultiPoint(vec);
 		ensure( mp != 0 );
 		ensure( mp->isValid() );
 		ensure( mp->isSimple() );
@@ -1025,7 +1031,7 @@ namespace tut
 		ensure_equals( mp->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(mp);
+		factory_->destroyGeometry(mp);
 		std::vector<GeometryPtr>::const_iterator it;
 		for (it = vec.begin(); it != vec.end(); ++it)
 		{
@@ -1048,7 +1054,7 @@ namespace tut
 		coords.setAt(Coordinate(10, 5), 2);
 		ensure_equals( coords.getSize(), size );
 
-		MultiPointPtr mp = factory_.createMultiPoint(coords);
+		MultiPointPtr mp = factory_->createMultiPoint(coords);
 		ensure( mp != 0 );
 		ensure( mp->isValid() );
 		ensure( mp->isSimple() );
@@ -1056,7 +1062,7 @@ namespace tut
 		ensure_equals( mp->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT );
 		
 		// FREE MEMORY
-		factory_.destroyGeometry(mp);
+		factory_->destroyGeometry(mp);
 	}
 
 	// Test of createMultiLineString() const
@@ -1064,7 +1070,7 @@ namespace tut
 	template<>
 	void object::test<28>()
 	{
-		MultiLineStringPtr mls = factory_.createMultiLineString();
+		MultiLineStringPtr mls = factory_->createMultiLineString();
 
 		ensure( "createMultiLineString() returned null pointer.", mls != 0 );
 		ensure( "createMultiLineString() returned non-empty point.", mls->isEmpty() );
@@ -1079,17 +1085,17 @@ namespace tut
 		//geo = poly->getEnvelope();
 		//ensure( geo != 0 );
 		//ensure( geo->isEmpty() );
-		//factory_.destroyGeometry(geo);
+		//factory_->destroyGeometry(geo);
 
 		geo = mls->getBoundary();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = mls->convexHull();
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( mls->getGeometryTypeId(), geos::geom::GEOS_MULTILINESTRING );
 		ensure_equals( mls->getDimension(), geos::geom::Dimension::L );
@@ -1099,7 +1105,7 @@ namespace tut
 		ensure_equals( mls->getArea(), 0.0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(mls);
+		factory_->destroyGeometry(mls);
 	}
 
 	// Test of createMultiLineString(std::vector<Geometry*>* newLines) const
@@ -1123,7 +1129,7 @@ namespace tut
 			coords->setAt(Coordinate(5 + factor, 5 + factor), 1);
 			ensure_equals( coords->getSize(), lineSize );
 
-			LineStringPtr line = factory_.createLineString(coords);
+			LineStringPtr line = factory_->createLineString(coords);
 			ensure( "createLineString() returned empty point.", !line->isEmpty() );
 			ensure_equals( line->getNumPoints(), lineSize );
 			ensure( line->isSimple() );
@@ -1133,7 +1139,7 @@ namespace tut
 			lines->push_back(line);
 		}
 
-		MultiLineStringPtr mls = factory_.createMultiLineString(lines);
+		MultiLineStringPtr mls = factory_->createMultiLineString(lines);
 		ensure( mls != 0 );
 		// TODO - mloskot - why isValid() returns false?
 		//ensure( mls->isValid() );
@@ -1141,7 +1147,7 @@ namespace tut
 		ensure_equals( mls->getGeometryTypeId(), geos::geom::GEOS_MULTILINESTRING );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(mls);
+		factory_->destroyGeometry(mls);
 	}
 
 	// Test of createMultiLineString(const std::vector<Geometry*>& fromLines) const
@@ -1165,7 +1171,7 @@ namespace tut
 			coords->setAt(Coordinate(5 + factor, 5 + factor), 1);
 			ensure_equals( coords->getSize(), lineSize );
 
-			LineStringPtr line = factory_.createLineString(coords);
+			LineStringPtr line = factory_->createLineString(coords);
 			ensure( "createLineString() returned empty point.", !line->isEmpty() );
 			ensure_equals( line->getNumPoints(), lineSize );
 			ensure( line->isSimple() );
@@ -1175,7 +1181,7 @@ namespace tut
 			lines.push_back(line);
 		}
 
-		MultiLineStringPtr mls = factory_.createMultiLineString(lines);
+		MultiLineStringPtr mls = factory_->createMultiLineString(lines);
 		ensure( mls != 0 );
 		// TODO - mloskot - why isValid() returns false?
 		//ensure( mls->isValid() );
@@ -1183,7 +1189,7 @@ namespace tut
 		ensure_equals( mls->getGeometryTypeId(), geos::geom::GEOS_MULTILINESTRING );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(mls);
+		factory_->destroyGeometry(mls);
 		std::vector<GeometryPtr>::const_iterator it;
 		for (it = lines.begin(); it != lines.end(); ++it)
 		{
@@ -1251,23 +1257,23 @@ namespace tut
 		PointVect vec;
 
 		PointPtr geo = 0;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 2;
 		coord.y *= 2;
 		coord.z *= 2;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		coord.x *= 3;
 		coord.y *= 3;
 		coord.z *= 3;
-		geo = factory_.createPoint(coord);
+		geo = factory_->createPoint(coord);
 		vec.push_back(geo);
 
 		// Factory creates copy of the vec collection
-		GeometryAutoPtr g = factory_.buildGeometry(vec.begin(), vec.end());
+		GeometryAutoPtr g = factory_->buildGeometry(vec.begin(), vec.end());
 		ensure( g.get() != 0 );
 		ensure_equals( g->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT );
 		ensure_equals( g->getNumGeometries(), size );
@@ -1278,18 +1284,6 @@ namespace tut
 		{
 			delete (*it);
 		}
-	}
-
-	// Test of autoDestroy
-	template<>
-	template<>
-	void object::test<37>()
-	{
-		geos::geom::GeometryFactory *fact = new geos::geom::GeometryFactory();
-		geos::geom::Geometry *pt = fact->createPoint();
-		fact->autoDestroy();
-		delete pt;
-		// check with valgrind that there's no memory leak !
 	}
 
 } // namespace tut

--- a/tests/unit/geom/GeometryFactoryTest.cpp
+++ b/tests/unit/geom/GeometryFactoryTest.cpp
@@ -1280,4 +1280,16 @@ namespace tut
 		}
 	}
 
+	// Test of autoDestroy
+	template<>
+	template<>
+	void object::test<37>()
+	{
+		geos::geom::GeometryFactory *fact = new geos::geom::GeometryFactory();
+		geos::geom::Geometry *pt = fact->createPoint();
+		fact->autoDestroy();
+		delete pt;
+		// check with valgrind that there's no memory leak !
+	}
+
 } // namespace tut

--- a/tests/unit/geom/LineStringTest.cpp
+++ b/tests/unit/geom/LineStringTest.cpp
@@ -33,21 +33,23 @@ namespace tut
 		typedef std::auto_ptr<geos::geom::LineString> LineStringAutoPtr;
 
 		geos::geom::PrecisionModel pm_;
-		geos::geom::GeometryFactory factory_;
+		geos::geom::GeometryFactory::unique_ptr factory_;
 		geos::io::WKTReader reader_;
 		
 		LineStringPtr empty_line_;
 
 		test_linestring_data()
-			: pm_(1000), factory_(&pm_, 0), reader_(&factory_),
-			empty_line_(factory_.createLineString(new geos::geom::CoordinateArraySequence()))
+			: pm_(1000)
+      , factory_(geos::geom::GeometryFactory::create(&pm_, 0))
+      , reader_(factory_.get())
+      , empty_line_(factory_->createLineString(new geos::geom::CoordinateArraySequence()))
 		{
             assert(0 != empty_line_);
         }
 		
         ~test_linestring_data()
         {
-            factory_.destroyGeometry(empty_line_);
+            factory_->destroyGeometry(empty_line_);
             empty_line_ = 0;
         }
     };
@@ -73,7 +75,7 @@ namespace tut
 		ensure( "sequence is null pointer.", pseq != 0 );
 
 		// Create empty linstring instance
-		LineStringAutoPtr ls(factory_.createLineString(pseq));
+		LineStringAutoPtr ls(factory_->createLineString(pseq));
 
 		ensure( ls->isEmpty() );
 		ensure( ls->isSimple() );
@@ -100,7 +102,7 @@ namespace tut
 		ensure_equals( pseq->size(), size3 );
 
 		// Create non-empty linstring instance
-		LineStringAutoPtr ls(factory_.createLineString(pseq));
+		LineStringAutoPtr ls(factory_->createLineString(pseq));
 
 		ensure( !ls->isEmpty() );
 		ensure( ls->isSimple() );
@@ -113,17 +115,17 @@ namespace tut
 		geo = ls->getEnvelope();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = ls->getBoundary();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = ls->convexHull();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( ls->getGeometryTypeId(), geos::geom::GEOS_LINESTRING );
 		ensure_equals( ls->getDimension(), geos::geom::Dimension::L );
@@ -149,7 +151,7 @@ namespace tut
 			ensure_equals( pseq->size(), 1u );
 
 			// Create incomplete linstring
-			LineStringAutoPtr ls(factory_.createLineString(pseq));
+			LineStringAutoPtr ls(factory_->createLineString(pseq));
 			fail("IllegalArgumentException expected.");
 		}
 		catch (geos::util::IllegalArgumentException const& e)
@@ -183,7 +185,7 @@ namespace tut
 		ensure_equals( pseq->size(), size );
 
 		// Create examplar of linstring instance
-		LineStringAutoPtr examplar(factory_.createLineString(pseq));
+		LineStringAutoPtr examplar(factory_->createLineString(pseq));
 
 		// Create copy
 		LineStringAutoPtr copy(dynamic_cast<geos::geom::LineString*>(examplar->clone()));
@@ -201,17 +203,17 @@ namespace tut
 		geo = copy->getEnvelope();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = copy->getBoundary();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		geo = copy->convexHull();
 		ensure( geo != 0 );
 		ensure( !geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 
 		ensure_equals( copy->getGeometryTypeId(), geos::geom::GEOS_LINESTRING );
 		ensure_equals( copy->getDimension(), geos::geom::Dimension::L );
@@ -239,7 +241,7 @@ namespace tut
 		geo = empty_line_->getEnvelope();	
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
     // Test of getBoundary() for empty linestring
@@ -251,7 +253,7 @@ namespace tut
 		geo = empty_line_->getBoundary();	
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
     // Test of convexHull() for empty linestring
@@ -263,7 +265,7 @@ namespace tut
 		geo = empty_line_->convexHull();	
 		ensure( geo != 0 );
 		ensure( geo->isEmpty() );
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
     // Test of getGeometryTypeId() for empty linestring
@@ -331,7 +333,7 @@ namespace tut
         ensure( line->getCoordinateDimension() == 2 );
 		
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(line);
+		factory_->destroyGeometry(line);
 	}
 
     // Test of getEnvelope() for non-empty linestring
@@ -350,10 +352,10 @@ namespace tut
 		ensure( !envelope->isEmpty() );
 		ensure_equals( envelope->getDimension(), geos::geom::Dimension::A );
 
-		factory_.destroyGeometry(envelope);
+		factory_->destroyGeometry(envelope);
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(line);
+		factory_->destroyGeometry(line);
 	}
 
 	// Test of getBoundary() for non-empty linestring
@@ -372,10 +374,10 @@ namespace tut
 		ensure( !boundary->isEmpty() );
 		ensure_equals( boundary->getGeometryTypeId(), geos::geom::GEOS_MULTIPOINT );
 		ensure_equals( boundary->getDimension(), geos::geom::Dimension::P );
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(line);
+		factory_->destroyGeometry(line);
 	}
 
 	// Test of convexHull() for non-empty linestring
@@ -394,10 +396,10 @@ namespace tut
 		ensure( !hull->isEmpty() );
 		ensure_equals( hull->getGeometryTypeId(), geos::geom::GEOS_POLYGON );
 		ensure_equals( hull->getDimension(), geos::geom::Dimension::A );
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(line);
+		factory_->destroyGeometry(line);
 	}
 
 	// Test of getGeometryTypeId() for non-empty linestring
@@ -411,7 +413,7 @@ namespace tut
 		ensure_equals( geo->getGeometryTypeId(), geos::geom::GEOS_LINESTRING );
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of getDimension() for non-empty linestring
@@ -425,7 +427,7 @@ namespace tut
 		ensure_equals( geo->getDimension(), geos::geom::Dimension::L );
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of getBoundaryDimension() for non-empty linestring
@@ -439,7 +441,7 @@ namespace tut
 		ensure_equals( geo->getBoundaryDimension(), geos::geom::Dimension::P );
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of getNumPoints() for non-empty linestring
@@ -454,7 +456,7 @@ namespace tut
 		ensure_equals( geo->getNumPoints(), size );
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of getLength() for non-empty linestring
@@ -473,7 +475,7 @@ namespace tut
 		ensure( diff <= tolerance );
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of getArea() for non-empty linestring
@@ -487,7 +489,7 @@ namespace tut
 		ensure_equals( geo->getArea(), 0.0 );
 
 		// FREE TESTED LINESTRING
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of getGeometryType() for non-empty Polygon
@@ -502,7 +504,7 @@ namespace tut
 		ensure_equals( geo->getGeometryType(), type );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 } // namespace tut

--- a/tests/unit/geom/LinearRingTest.cpp
+++ b/tests/unit/geom/LinearRingTest.cpp
@@ -40,7 +40,7 @@ namespace tut
 		typedef geos::geom::LinearRing const* LinearRingCPtr;
 
 		geos::geom::PrecisionModel pm_;
-		geos::geom::GeometryFactory factory_;
+		geos::geom::GeometryFactory::unique_ptr factory_;
 		geos::io::WKTReader reader_;
 
 		geos::geom::LinearRing empty_ring_;
@@ -48,8 +48,9 @@ namespace tut
 		const size_t ring_size_;
 
 		test_linearring_data()
-			: pm_(1000), factory_(&pm_, 0), reader_(&factory_),
-			empty_ring_(new geos::geom::CoordinateArraySequence(), &factory_),
+			: pm_(1000), factory_(geos::geom::GeometryFactory::create(&pm_, 0))
+      , reader_(factory_.get())
+      , empty_ring_(new geos::geom::CoordinateArraySequence(), factory_.get()),
 			ring_size_(7)
 		{
 			// Create non-empty LinearRing
@@ -60,7 +61,7 @@ namespace tut
 
 		~test_linearring_data()
 		{
-			factory_.destroyGeometry(ring_);
+			factory_->destroyGeometry(ring_);
         }
 
     private:
@@ -103,7 +104,7 @@ namespace tut
 		try
 		{
 			// Create non-empty linearring instance
-			geos::geom::LinearRing ring(coords, &factory_);
+			geos::geom::LinearRing ring(coords, factory_.get());
 			ensure( !ring.isEmpty() );
 			ensure( ring.isClosed() );
 			ensure( ring.isRing() );
@@ -176,7 +177,7 @@ namespace tut
 		GeometryPtr envelope = empty_ring_.getEnvelope();	
 		ensure( envelope != 0 );
 		ensure( envelope->isEmpty() );
-		factory_.destroyGeometry(envelope);
+		factory_->destroyGeometry(envelope);
 	}
 
 	// Test of getBoundary() for empty LinearRing
@@ -187,7 +188,7 @@ namespace tut
 		GeometryPtr boundary = empty_ring_.getBoundary();	
 		ensure( boundary != 0 );
 		ensure( boundary->isEmpty() );
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 	}
 
 	// Test of convexHull() for empty LinearRing
@@ -198,7 +199,7 @@ namespace tut
 		GeometryPtr hull = empty_ring_.convexHull();	
 		ensure( hull != 0 );
 		ensure( hull->isEmpty() );
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 	}
 
 	// Test of getGeometryTypeId() for empty LinearRing
@@ -281,7 +282,7 @@ namespace tut
 		ensure_equals( envelope->getDimension(), geos::geom::Dimension::A );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(envelope);
+		factory_->destroyGeometry(envelope);
 	}
 
 	// Test of getBoundary() for non-empty LinearRing
@@ -298,7 +299,7 @@ namespace tut
 		ensure( "[OGC] The boundary of a closed Curve must be empty.", boundary->isEmpty() );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 	}
 
 	// Test of convexHull() for non-empty LinearRing
@@ -315,7 +316,7 @@ namespace tut
 		ensure_equals( hull->getDimension(), geos::geom::Dimension::A );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 	}
 
 	// Test of getGeometryTypeId() for non-empty LinearRing
@@ -388,7 +389,7 @@ namespace tut
 			ensure(geo != 0);
 
 			// FREE TESTED LINEARRING
-			factory_.destroyGeometry(geo);
+			factory_->destroyGeometry(geo);
 
 			fail("IllegalArgumentException expected.");
 		}
@@ -416,7 +417,7 @@ namespace tut
 			ensure( !ring->isValid() );
 
 			// FREE TESTED LINEARRING
-			factory_.destroyGeometry(geo);
+			factory_->destroyGeometry(geo);
 
 			fail("IllegalArgumentException expected.");
 		}

--- a/tests/unit/geom/MultiPointTest.cpp
+++ b/tests/unit/geom/MultiPointTest.cpp
@@ -25,9 +25,10 @@ namespace tut
 	struct test_multipoint_data
 	{
 		typedef std::auto_ptr<geos::geom::MultiPoint> MultiPointAutoPtr;
+		typedef geos::geom::GeometryFactory GeometryFactory;
 
 		geos::geom::PrecisionModel pm_;
-		geos::geom::GeometryFactory factory_;
+		geos::geom::GeometryFactory::unique_ptr factory_;
 		geos::io::WKTReader reader_;
 
 		MultiPointAutoPtr empty_mp_;
@@ -36,8 +37,9 @@ namespace tut
 
 		test_multipoint_data()
 			:
-			pm_(1.0), factory_(&pm_, 0), reader_(&factory_),
-			empty_mp_(factory_.createMultiPoint()), mp_size_(5)
+			pm_(1.0), factory_(GeometryFactory::create(&pm_, 0))
+      , reader_(factory_.get())
+      , empty_mp_(factory_->createMultiPoint()), mp_size_(5)
 		{
 			// Create non-empty MultiPoint
 			GeometryPtr geo = 0;
@@ -47,7 +49,7 @@ namespace tut
 
 		~test_multipoint_data()
 		{
-			factory_.destroyGeometry(mp_);
+			factory_->destroyGeometry(mp_);
 		}
 
     private:
@@ -71,7 +73,7 @@ namespace tut
 	void object::test<1>()
 	{
 		const size_t size0 = 0;
-		MultiPointAutoPtr mp(factory_.createMultiPoint());
+		MultiPointAutoPtr mp(factory_->createMultiPoint());
 		
 		ensure( mp->isEmpty() );
 		ensure( mp->isSimple() );
@@ -115,7 +117,7 @@ namespace tut
 		ensure_equals( mp->getNumGeometries(), size0 );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of isEmpty() for empty MultiPoint
@@ -150,7 +152,7 @@ namespace tut
 		GeometryPtr envelope = empty_mp_->getEnvelope();	
 		ensure( envelope != 0 );
 		ensure( envelope->isEmpty() );
-		factory_.destroyGeometry(envelope);
+		factory_->destroyGeometry(envelope);
 	}
 
 	// Test of getBoundary() for empty MultiPoint
@@ -161,7 +163,7 @@ namespace tut
 		GeometryPtr boundary = empty_mp_->getBoundary();	
 		ensure( boundary != 0 );
 		ensure( boundary->isEmpty() );
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 	}
 
 	// Test of convexHull() for empty MultiPoint
@@ -172,7 +174,7 @@ namespace tut
 		GeometryPtr hull = empty_mp_->convexHull();	
 		ensure( hull != 0 );
 		ensure( hull->isEmpty() );
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 	}
 
 	// Test of getGeometryTypeId() for empty MultiPoint
@@ -254,7 +256,7 @@ namespace tut
 		ensure_equals( envelope->getDimension(), geos::geom::Dimension::A );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(envelope);
+		factory_->destroyGeometry(envelope);
 	}
 
 	// Test of getBoundary() for non-empty LinearRing
@@ -271,7 +273,7 @@ namespace tut
 		ensure( "[OGC] The boundary of a MultiPoint is the empty set.", boundary->isEmpty() );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 	}
 
 	// Test of convexHull() for non-empty LinearRing
@@ -288,7 +290,7 @@ namespace tut
 		ensure_equals( hull->getDimension(), geos::geom::Dimension::L );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 	}
 
 	// Test of getGeometryTypeId() for non-empty LinearRing
@@ -367,7 +369,7 @@ namespace tut
 			ensure(geo != 0);
 
 			// FREE TESTED LINEARRING
-			factory_.destroyGeometry(geo);
+			factory_->destroyGeometry(geo);
 
 			fail("ParseException expected.");
 		}

--- a/tests/unit/geom/PointTest.cpp
+++ b/tests/unit/geom/PointTest.cpp
@@ -36,15 +36,17 @@ namespace tut
 	typedef geos::geom::Point* PointPtr;
 	typedef std::auto_ptr<geos::geom::Point> PointAutoPtr;
 	typedef geos::geom::Point const* PointCPtr;
+	typedef geos::geom::GeometryFactory GeometryFactory;
 
 	geos::geom::PrecisionModel pm_;
-	geos::geom::GeometryFactory factory_;
+	GeometryFactory::unique_ptr factory_;
 	geos::io::WKTReader reader_;
 	PointAutoPtr empty_point_;
 	PointPtr point_;
 
 	test_point_data()
-	    : pm_(1000), factory_(&pm_, 0), reader_(&factory_), empty_point_(factory_.createPoint())
+	    : pm_(1000), factory_(GeometryFactory::create(&pm_, 0))
+      , reader_(factory_.get()), empty_point_(factory_->createPoint())
 	{
 	    // Create non-empty Point
 	    GeometryPtr geo = 0;
@@ -54,7 +56,7 @@ namespace tut
 	
 	~test_point_data()
 	{
-	    factory_.destroyGeometry(point_);
+	    factory_->destroyGeometry(point_);
 	}
     };
 
@@ -72,7 +74,7 @@ namespace tut
     template<>
     void object::test<1>()
     {
-		PointAutoPtr point(factory_.createPoint());
+		PointAutoPtr point(factory_->createPoint());
 		ensure( point->isEmpty() );
     }
 
@@ -88,7 +90,7 @@ namespace tut
 		ensure( coords != 0 );
 		coords->add(Coordinate(1.234, 5.678));
 
-		PointAutoPtr point(factory_.createPoint(coords));
+		PointAutoPtr point(factory_->createPoint(coords));
 		ensure( !point->isEmpty() );
         
         // currently the empty CoordinateArraySequence constructor 
@@ -113,7 +115,7 @@ namespace tut
 			coords->add(Coordinate(1.234, 5.678));
 			coords->add(Coordinate(4.321, 8.765));
 
-			PointAutoPtr point(factory_.createPoint(coords));
+			PointAutoPtr point(factory_->createPoint(coords));
 
 			fail("IllegalArgumentException expected.");
 		}
@@ -168,7 +170,7 @@ namespace tut
 		GeometryPtr envelope = empty_point_->getEnvelope();	
 		ensure( envelope != 0 );
 		ensure( envelope->isEmpty() );
-		factory_.destroyGeometry(envelope);
+		factory_->destroyGeometry(envelope);
 	}
 
 	// Test of getBoundary() for empty Point
@@ -179,7 +181,7 @@ namespace tut
 		GeometryPtr boundary = empty_point_->getBoundary();	
 		ensure( boundary != 0 );
 		ensure( boundary->isEmpty() );
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 	}
 
 	// Test of convexHull() for empty Point
@@ -190,7 +192,7 @@ namespace tut
 		GeometryPtr hull = empty_point_->convexHull();	
 		ensure( hull != 0 );
 		ensure( hull->isEmpty() );
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 	}
 
 	// Test of getGeometryTypeId() for empty Point
@@ -282,7 +284,7 @@ namespace tut
 		GeometryPtr envelope = point_->getEnvelope();	
 		ensure( envelope != 0 );
 		ensure( !envelope->isEmpty() );
-		factory_.destroyGeometry(envelope);
+		factory_->destroyGeometry(envelope);
 	}
 
 	// Test of getBoundary() for non-empty Point
@@ -293,7 +295,7 @@ namespace tut
 		GeometryPtr boundary = point_->getBoundary();	
 		ensure( boundary != 0 );
 		ensure( boundary->isEmpty() );
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 	}
 
 	// Test of convexHull() for non-empty Point
@@ -304,7 +306,7 @@ namespace tut
 		GeometryPtr hull = point_->convexHull();	
 		ensure( hull != 0 );
 		ensure( !hull->isEmpty() );
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 	}
 
 	// Test of getGeometryTypeId() for non-empty Point
@@ -386,8 +388,8 @@ namespace tut
 		ensure( p1->equals(p2) );
 		
 		// FREE MEMORY
-		factory_.destroyGeometry(p1);
-		factory_.destroyGeometry(p2);
+		factory_->destroyGeometry(p1);
+		factory_->destroyGeometry(p2);
 	}
 
 	// Test of equals() for non-empty Point (1.23 5.67)
@@ -402,8 +404,8 @@ namespace tut
 		ensure( p1->equals(p2) );
 		
 		// FREE MEMORY
-		factory_.destroyGeometry(p1);
-		factory_.destroyGeometry(p2);
+		factory_->destroyGeometry(p1);
+		factory_->destroyGeometry(p2);
 	}
 
 	// Test of equals() for non-empty Points (1.235 5.678) and (1.234 5.678)
@@ -418,8 +420,8 @@ namespace tut
 		ensure( !p1->equals(p2) );
 		
 		// FREE MEMORY
-		factory_.destroyGeometry(p1);
-		factory_.destroyGeometry(p2);
+		factory_->destroyGeometry(p1);
+		factory_->destroyGeometry(p2);
 	}
 
 	// Test of equals() for non-empty Points (1.2334 5.678) and (1.2333 5.678)
@@ -434,8 +436,8 @@ namespace tut
 		ensure( p1->equals(p2) );
 		
 		// FREE MEMORY
-		factory_.destroyGeometry(p1);
-		factory_.destroyGeometry(p2);
+		factory_->destroyGeometry(p1);
+		factory_->destroyGeometry(p2);
 	}
 
 	// Test of equals() for non-empty Points (1.2334 5.678) and (1.2335 5.678)
@@ -450,8 +452,8 @@ namespace tut
 		ensure( !p1->equals(p2) );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(p1);
-		factory_.destroyGeometry(p2);
+		factory_->destroyGeometry(p1);
+		factory_->destroyGeometry(p2);
 	}
 
 	// Test of equals() for non-empty Points (1.2324 5.678) and (1.2325 5.678)
@@ -466,8 +468,8 @@ namespace tut
 		ensure( !p1->equals(p2) );
 		
 		// FREE MEMORY
-		factory_.destroyGeometry(p1);
-		factory_.destroyGeometry(p2);
+		factory_->destroyGeometry(p1);
+		factory_->destroyGeometry(p2);
 	}
 
 	// Test of equals() for non-empty Points (1.2324 5.678) and (EMPTY)
@@ -482,8 +484,8 @@ namespace tut
 		ensure( !p1->equals(p2) );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(p1);
-		factory_.destroyGeometry(p2);
+		factory_->destroyGeometry(p1);
+		factory_->destroyGeometry(p2);
 	}
 
 	// Test of equals() for non-empty Points with negative coordiantes
@@ -506,11 +508,11 @@ namespace tut
 		ensure( p3->equals(pHi) );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(pLo);
-		factory_.destroyGeometry(pHi);
-		factory_.destroyGeometry(p1);
-		factory_.destroyGeometry(p2);
-		factory_.destroyGeometry(p3);
+		factory_->destroyGeometry(pLo);
+		factory_->destroyGeometry(pHi);
+		factory_->destroyGeometry(p1);
+		factory_->destroyGeometry(p2);
+		factory_->destroyGeometry(p3);
 	}
 
 	// Test of getCoordinateDimension() for 2d/3d.

--- a/tests/unit/geom/PolygonTest.cpp
+++ b/tests/unit/geom/PolygonTest.cpp
@@ -33,9 +33,10 @@ namespace tut
 		// Typedefs used as short names by test cases
 		typedef std::auto_ptr<geos::geom::Geometry> GeometryAutoPtr;
 		typedef std::auto_ptr<geos::geom::Polygon> PolygonAutoPtr;
+		typedef geos::geom::GeometryFactory GeometryFactory;
 
 		geos::geom::PrecisionModel pm_;
-		geos::geom::GeometryFactory factory_;
+		GeometryFactory::unique_ptr factory_;
 		geos::io::WKTReader reader_;
 
 		PolygonAutoPtr empty_poly_;
@@ -43,8 +44,10 @@ namespace tut
 		const size_t poly_size_;
 
 		test_polygon_data() 
-			: pm_(1), factory_(&pm_, 0), reader_(&factory_),
-                empty_poly_(factory_.createPolygon()), poly_size_(7)
+			: pm_(1)
+      , factory_(GeometryFactory::create(&pm_, 0))
+      , reader_(factory_.get())
+      , empty_poly_(factory_->createPolygon()), poly_size_(7)
 		{
 			// Create non-empty LinearRing
 			GeometryPtr geo = 0;
@@ -55,7 +58,7 @@ namespace tut
         ~test_polygon_data() 
         {
             // FREE MEMORY
-            factory_.destroyGeometry(poly_);
+            factory_->destroyGeometry(poly_);
         }
 
     private:
@@ -98,7 +101,7 @@ namespace tut
 		try
 		{
 			// Create non-empty LinearRing instance
-			geos::geom::LinearRing ring(coords, &factory_);
+			geos::geom::LinearRing ring(coords, factory_.get());
 			ensure( !ring.isEmpty() );
 			ensure( ring.isClosed() );
 			ensure( ring.isRing() );
@@ -110,7 +113,7 @@ namespace tut
 			
 			// Create non-empty Polygon
 			//geos::geom::Polygon poly(exterior, 0, &factory_);
-			PolygonAutoPtr poly(factory_.createPolygon(exterior, 0));
+			PolygonAutoPtr poly(factory_->createPolygon(exterior, 0));
 			
 			ensure( !poly->isEmpty() );
 			ensure( poly->isSimple() );
@@ -186,7 +189,7 @@ namespace tut
 		GeometryPtr boundary = empty_poly_->getBoundary();	
 		ensure( boundary != 0 );
 		ensure( boundary->isEmpty() );
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 	}
 
 	// Test of convexHull() for empty Polygon
@@ -197,7 +200,7 @@ namespace tut
 		GeometryPtr hull = empty_poly_->convexHull();	
 		ensure( hull != 0 );
 		ensure( hull->isEmpty() );
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 	}
 
 	// Test of getGeometryTypeId() for empty Polygon
@@ -270,7 +273,7 @@ namespace tut
 		ensure_equals( envelope->getDimension(), geos::geom::Dimension::A );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(envelope);
+		factory_->destroyGeometry(envelope);
 	}
 
 	// Test of getBoundary() for non-empty Polygon
@@ -287,7 +290,7 @@ namespace tut
 		ensure( "[OGC] The boundary of Polygin is the set of closed Curves.", !boundary->isEmpty() );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(boundary);
+		factory_->destroyGeometry(boundary);
 	}
 
 	// Test of convexHull() for non-empty Polygon
@@ -304,7 +307,7 @@ namespace tut
 		ensure_equals( hull->getDimension(), geos::geom::Dimension::A );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(hull);
+		factory_->destroyGeometry(hull);
 	}
 
 	// Test of getGeometryTypeId() for non-empty Polygon
@@ -394,7 +397,7 @@ namespace tut
 		ensure( geo != 0 );
 		ensure( geo->equals(poly_) );
 
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of getExteriorRing() for non-empty Polygon
@@ -441,7 +444,7 @@ namespace tut
 
 		ensure_equals( interior->getGeometryTypeId(), geos::geom::GEOS_LINEARRING );
 
-		factory_.destroyGeometry(geo);
+		factory_->destroyGeometry(geo);
 	}
 
 	// Test of getCoordiante() for non-empty Polygon
@@ -524,7 +527,7 @@ namespace tut
 		ensure_equals( point->getGeometryTypeId(), geos::geom::GEOS_POINT );
 
 		// FREE MEMORY
-		factory_.destroyGeometry(point);
+		factory_->destroyGeometry(point);
 	}
 
 	// Test of Geometry::getCentroid(Coordinate& ret) const for non-empty Polygon
@@ -552,7 +555,7 @@ namespace tut
 		ensure( pointCoord != 0 );
 		geos::geom::Coordinate pointCentr(*pointCoord);
 		// FREE MEMORY
-		factory_.destroyGeometry(point);
+		factory_->destroyGeometry(point);
 
 		// Second centroid
 		geos::geom::Coordinate coordCentr;

--- a/tests/unit/geom/prep/PreparedGeometryFactoryTest.cpp
+++ b/tests/unit/geom/prep/PreparedGeometryFactoryTest.cpp
@@ -27,14 +27,17 @@ namespace tut
     // Common data used by tests
     struct test_preparedgeometryfactory_data
     {
+        typedef geos::geom::GeometryFactory GeometryFactory;
         GeometryPtr g_;
         PreparedGeometryPtr pg_;
         geos::geom::PrecisionModel pm_;
-        geos::geom::GeometryFactory factory_;
+        geos::geom::GeometryFactory::unique_ptr factory_;
         geos::io::WKTReader reader_;
 
         test_preparedgeometryfactory_data()
-            : g_(0), pg_(0), pm_(1.0), factory_(&pm_), reader_(&factory_)
+            : g_(0), pg_(0), pm_(1.0)
+            , factory_(GeometryFactory::create(&pm_))
+            , reader_(factory_.get())
         {
             assert(0 == g_);
             assert(0 == pg_);
@@ -44,7 +47,7 @@ namespace tut
         {
             // FREE MEMORY per test case
             prep::PreparedGeometryFactory::destroy(pg_);
-            factory_.destroyGeometry(g_);
+            factory_->destroyGeometry(g_);
             pg_ = 0;
             g_ = 0;
         }
@@ -115,7 +118,7 @@ namespace tut
     template<>
     void object::test<4>()
     {
-        g_ = factory_.createEmptyGeometry();
+        g_ = factory_->createEmptyGeometry();
         ensure( 0 != g_ );
         
         pg_ = prep::PreparedGeometryFactory::prepare(g_);
@@ -129,7 +132,7 @@ namespace tut
     template<>
     void object::test<5>()
     {
-        g_ = factory_.createEmptyGeometry();
+        g_ = factory_->createEmptyGeometry();
         ensure( 0 != g_ );
         
         prep::PreparedGeometryFactory pgf;
@@ -144,7 +147,7 @@ namespace tut
     template<>
     void object::test<6>()
     {
-        g_ = factory_.createPoint();
+        g_ = factory_->createPoint();
         ensure( 0 != g_ );
         
         pg_ = prep::PreparedGeometryFactory::prepare(g_);
@@ -158,7 +161,7 @@ namespace tut
     template<>
     void object::test<7>()
     {
-        g_ = factory_.createPoint();
+        g_ = factory_->createPoint();
         ensure( 0 != g_ );
         
         prep::PreparedGeometryFactory pgf;
@@ -173,7 +176,7 @@ namespace tut
     template<>
     void object::test<8>()
     {
-        g_ = factory_.createLineString();
+        g_ = factory_->createLineString();
         ensure( 0 != g_ );
         
         pg_ = prep::PreparedGeometryFactory::prepare(g_);
@@ -187,7 +190,7 @@ namespace tut
     template<>
     void object::test<9>()
     {
-        g_ = factory_.createLineString();
+        g_ = factory_->createLineString();
         ensure( 0 != g_ );
         
         prep::PreparedGeometryFactory pgf;
@@ -201,7 +204,7 @@ namespace tut
     template<>
     void object::test<10>()
     {
-        g_ = factory_.createPolygon();
+        g_ = factory_->createPolygon();
         ensure( 0 != g_ );
         
         pg_ = prep::PreparedGeometryFactory::prepare(g_);
@@ -215,7 +218,7 @@ namespace tut
     template<>
     void object::test<11>()
     {
-        g_ = factory_.createPolygon();
+        g_ = factory_->createPolygon();
         ensure( 0 != g_ );
         
         prep::PreparedGeometryFactory pgf;
@@ -230,7 +233,7 @@ namespace tut
     template<>
     void object::test<12>()
     {
-        g_ = factory_.createMultiPoint();
+        g_ = factory_->createMultiPoint();
         ensure( 0 != g_ );
         
         pg_ = prep::PreparedGeometryFactory::prepare(g_);
@@ -244,7 +247,7 @@ namespace tut
     template<>
     void object::test<13>()
     {
-        g_ = factory_.createMultiPoint();
+        g_ = factory_->createMultiPoint();
         ensure( 0 != g_ );
         
         prep::PreparedGeometryFactory pgf;
@@ -259,7 +262,7 @@ namespace tut
     template<>
     void object::test<14>()
     {
-        g_ = factory_.createMultiLineString();
+        g_ = factory_->createMultiLineString();
         ensure( 0 != g_ );
         
         pg_ = prep::PreparedGeometryFactory::prepare(g_);
@@ -273,7 +276,7 @@ namespace tut
     template<>
     void object::test<15>()
     {
-        g_ = factory_.createMultiLineString();
+        g_ = factory_->createMultiLineString();
         ensure( 0 != g_ );
         
         prep::PreparedGeometryFactory pgf;
@@ -288,7 +291,7 @@ namespace tut
     template<>
     void object::test<16>()
     {
-        g_ = factory_.createMultiPolygon();
+        g_ = factory_->createMultiPolygon();
         ensure( 0 != g_ );
         
         pg_ = prep::PreparedGeometryFactory::prepare(g_);
@@ -302,7 +305,7 @@ namespace tut
     template<>
     void object::test<17>()
     {
-        g_ = factory_.createMultiPolygon();
+        g_ = factory_->createMultiPolygon();
         ensure( 0 != g_ );
         
         prep::PreparedGeometryFactory pgf;

--- a/tests/unit/geom/util/GeometryExtracterTest.cpp
+++ b/tests/unit/geom/util/GeometryExtracterTest.cpp
@@ -26,7 +26,7 @@ namespace tut
     struct test_geometryextracter_data
     {
       geos::geom::PrecisionModel pm;
-      geos::geom::GeometryFactory gf;
+      geos::geom::GeometryFactory::unique_ptr gf;
       geos::io::WKTReader wktreader;
       geos::io::WKTWriter wktwriter;
 
@@ -38,8 +38,8 @@ namespace tut
       test_geometryextracter_data()
         :
         pm(1.0),
-        gf(&pm),
-        wktreader(&gf)
+        gf(geos::geom::GeometryFactory::create(&pm)),
+        wktreader(gf.get())
       {
       }
     };

--- a/tests/unit/io/WKBReaderTest.cpp
+++ b/tests/unit/io/WKBReaderTest.cpp
@@ -31,7 +31,7 @@ namespace tut
 	struct test_wkbreader_data
 	{
 		geos::geom::PrecisionModel pm;
-		geos::geom::GeometryFactory gf;
+		geos::geom::GeometryFactory::unique_ptr gf;
 		geos::io::WKBReader wkbreader;
 		geos::io::WKBWriter xdrwkbwriter;
 		geos::io::WKBWriter ndrwkbwriter;
@@ -42,13 +42,13 @@ namespace tut
 		test_wkbreader_data()
 			:
 			pm(1.0),
-			gf(&pm),
-			wkbreader(gf),
+			gf(geos::geom::GeometryFactory::create(&pm)),
+			wkbreader(*gf),
 			// 2D only, XDR (big endian)
 			xdrwkbwriter(2, geos::io::WKBConstants::wkbXDR),
 			// 2D only, NDR (little endian)
 			ndrwkbwriter(2, geos::io::WKBConstants::wkbNDR),
-			wktreader(&gf)
+			wktreader(gf.get())
 		{}
 
 		void testInputOutput(const std::string& WKT,

--- a/tests/unit/io/WKBWriterTest.cpp
+++ b/tests/unit/io/WKBWriterTest.cpp
@@ -27,7 +27,7 @@ namespace tut
 	struct test_wkbwriter_data
 	{
 		geos::geom::PrecisionModel pm;
-		geos::geom::GeometryFactory gf;
+		geos::geom::GeometryFactory::unique_ptr gf;
 		geos::io::WKTReader wktreader;
 		geos::io::WKTWriter wktwriter;
 		geos::io::WKBReader wkbreader;
@@ -36,9 +36,9 @@ namespace tut
 		test_wkbwriter_data()
 			:
 			pm(1000.0),
-			gf(&pm),
-      wktreader(&gf),
-      wkbreader(gf)
+			gf(geos::geom::GeometryFactory::create(&pm)),
+      wktreader(gf.get()),
+      wkbreader(*gf)
 		{}
 
 	};
@@ -144,7 +144,7 @@ namespace tut
     GeomVect *geoms = new GeomVect;
     geoms->push_back( wktreader.read("POLYGON((0 0,1 0,1 1,0 1,0 0))") );
     geoms->back()->setSRID(4326);
-    Geom *geom = gf.createGeometryCollection(geoms);
+    Geom *geom = gf->createGeometryCollection(geoms);
     std::stringstream result_stream;
 
     wkbwriter.setOutputDimension( 2 );

--- a/tests/unit/io/WKTReaderTest.cpp
+++ b/tests/unit/io/WKTReaderTest.cpp
@@ -26,7 +26,7 @@ namespace tut
 	struct test_wktreader_data
 	{
 		geos::geom::PrecisionModel pm;
-		geos::geom::GeometryFactory gf;
+		geos::geom::GeometryFactory::unique_ptr gf;
 		geos::io::WKTReader wktreader;
 		geos::io::WKTWriter wktwriter;
 
@@ -35,8 +35,8 @@ namespace tut
 		test_wktreader_data()
 			:
 			pm(1.0),
-			gf(&pm),
-			wktreader(&gf)
+			gf(geos::geom::GeometryFactory::create(&pm)),
+			wktreader(gf.get())
 		{
             wktwriter.setOutputDimension( 3 );
         }
@@ -150,8 +150,8 @@ namespace tut
             namespace ggm = geos::geom;
             namespace gio = geos::io;
             ggm::PrecisionModel pm(ggm::PrecisionModel::FLOATING);
-            ggm::GeometryFactory gf(&pm);
-            gio::WKTReader wktReader(&gf);
+            ggm::GeometryFactory::unique_ptr gf = ggm::GeometryFactory::create(&pm);
+            gio::WKTReader wktReader(gf.get());
             const std::string str = " POINT (0 0) ";
             geom.reset(wktReader.read(str)); //HERE IT FAILS
 

--- a/tests/unit/io/WKTWriterTest.cpp
+++ b/tests/unit/io/WKTWriterTest.cpp
@@ -30,15 +30,15 @@ namespace tut
 		typedef std::auto_ptr<geos::geom::Geometry> GeomPtr;
 
 		PrecisionModel pm;
-		GeometryFactory gf;
+		GeometryFactory::unique_ptr gf;
 		WKTReader wktreader;
 		WKTWriter wktwriter;
 
 		test_wktwriter_data()
                 :
                 pm(1000.0),
-                gf(&pm),
-                wktreader(&gf)
+                gf(GeometryFactory::create(&pm)),
+                wktreader(gf.get())
             {}
 
 	};
@@ -138,8 +138,8 @@ namespace tut
   void object::test<5>()
   {         
     PrecisionModel pm3(0.001);
-    GeometryFactory gf3(&pm3);
-    WKTReader wktreader3(&gf3);
+    GeometryFactory::unique_ptr gf3(GeometryFactory::create(&pm3));
+    WKTReader wktreader3(gf3.get());
     GeomPtr geom ( wktreader3.read("POINT(123456 654321)") );
 
     std::string  result = wktwriter.write( geom.get() );

--- a/tests/unit/linearref/LengthIndexedLineTest.cpp
+++ b/tests/unit/linearref/LengthIndexedLineTest.cpp
@@ -36,13 +36,11 @@ static const double TOLERANCE_DIST = 0.001;
 struct test_lengthindexedline_data
 {
     test_lengthindexedline_data()
-        : pm(), gf(&pm), reader(&gf), writer()
+        : reader(), writer()
     {
       writer.setTrim(true);
     }
     
-    PrecisionModel pm;
-    GeometryFactory gf;
     geos::io::WKTReader reader;
     geos::io::WKTWriter writer;
     

--- a/tests/unit/noding/OrientedCoordinateArray.cpp
+++ b/tests/unit/noding/OrientedCoordinateArray.cpp
@@ -26,15 +26,19 @@ namespace tut
     // Common data used by all tests
     struct test_orientedcoordinatearray_data
     {
+        typedef geos::geom::GeometryFactory GeometryFactory;
+
         geos::geom::PrecisionModel pm_;
-        geos::geom::GeometryFactory factory_;
+        GeometryFactory::unique_ptr factory_;
         geos::io::WKTReader reader_;
 
         typedef std::auto_ptr<CoordinateSequence> CoordSeqPtr;
         typedef std::auto_ptr<Geometry> GeomPtr;
 
         test_orientedcoordinatearray_data()
-          : pm_(), factory_(&pm_), reader_(&factory_) {}
+          : pm_()
+          , factory_(GeometryFactory::create(&pm_))
+          , reader_(factory_.get()) {}
 
         CoordSeqPtr coords_from_wkt(const char *wkt) {
           GeomPtr g ( reader_.read(wkt) );

--- a/tests/unit/noding/snapround/MCIndexSnapRounderTest.cpp
+++ b/tests/unit/noding/snapround/MCIndexSnapRounderTest.cpp
@@ -55,10 +55,10 @@ namespace tut
       typedef std::vector<SegmentString*> SegStrVct;
       typedef std::vector<Geometry*> GeomVct;
 
-      const geos::geom::GeometryFactory gf_;
+      const geos::geom::GeometryFactory *gf_;
 
       test_mcidxsnprndr_data()
-            : gf_()
+            : gf_(geos::geom::GeometryFactory::getDefaultInstance())
       {}
 
       GeomPtr getGeometry(SegStrVct& vct)
@@ -67,9 +67,9 @@ namespace tut
         for (SegStrVct::size_type i=0, n=vct.size(); i<n; ++i)
         {
           SegmentString* ss = vct[i];
-          lines->push_back( gf_.createLineString(*(ss->getCoordinates())) );
+          lines->push_back( gf_->createLineString(*(ss->getCoordinates())) );
         }
-        return GeomPtr(gf_.createMultiLineString(lines));
+        return GeomPtr(gf_->createMultiLineString(lines));
       }
 
       void getSegmentStrings(const Geometry& g, SegStrVct& vct)

--- a/tests/unit/operation/IsSimpleOpTest.cpp
+++ b/tests/unit/operation/IsSimpleOpTest.cpp
@@ -26,13 +26,17 @@ namespace tut
 
     struct test_issimpleop_data
     {
+        typedef geos::geom::GeometryFactory GeometryFactory;
         geos::geom::PrecisionModel pm_;
-        geos::geom::GeometryFactory factory_;
+        GeometryFactory::unique_ptr factory_;
         geos::io::WKTReader reader_;
         double tolerance_;
 
         test_issimpleop_data()
-			: pm_(1), factory_(&pm_, 0), reader_(&factory_), tolerance_(0.00005)
+			: pm_(1)
+      , factory_(GeometryFactory::create(&pm_, 0))
+      , reader_(factory_.get())
+      , tolerance_(0.00005)
         {}
     };
 

--- a/tests/unit/operation/buffer/BufferBuilderTest.cpp
+++ b/tests/unit/operation/buffer/BufferBuilderTest.cpp
@@ -29,7 +29,7 @@ namespace tut
     // Common data used by tests
     struct test_bufferbuilder_data
     {
-        geos::geom::GeometryFactory gf;
+        const geos::geom::GeometryFactory &gf;
         geos::io::WKTReader wktreader;
         int const default_quadrant_segments;
 
@@ -37,7 +37,9 @@ namespace tut
         typedef std::auto_ptr<geos::geom::CoordinateSequence> CSPtr;
 
         test_bufferbuilder_data()
-            : gf(), wktreader(&gf), default_quadrant_segments(geos::operation::buffer::BufferParameters::DEFAULT_QUADRANT_SEGMENTS)
+            : gf(*geos::geom::GeometryFactory::getDefaultInstance())
+            , wktreader(&gf)
+            , default_quadrant_segments(geos::operation::buffer::BufferParameters::DEFAULT_QUADRANT_SEGMENTS)
         {
             ensure_equals(default_quadrant_segments, int(8));
         }

--- a/tests/unit/operation/buffer/BufferOpTest.cpp
+++ b/tests/unit/operation/buffer/BufferOpTest.cpp
@@ -27,7 +27,7 @@ namespace tut
     // Common data used by tests
     struct test_bufferop_data
     {
-        geos::geom::GeometryFactory gf;
+        const geos::geom::GeometryFactory &gf;
         geos::io::WKTReader wktreader;
         int const default_quadrant_segments;
 
@@ -35,7 +35,9 @@ namespace tut
         typedef std::auto_ptr<geos::geom::CoordinateSequence> CSPtr;
 
         test_bufferop_data()
-            : gf(), wktreader(&gf), default_quadrant_segments(geos::operation::buffer::BufferParameters::DEFAULT_QUADRANT_SEGMENTS)
+            : gf(*geos::geom::GeometryFactory::getDefaultInstance())
+            , wktreader(&gf)
+            , default_quadrant_segments(geos::operation::buffer::BufferParameters::DEFAULT_QUADRANT_SEGMENTS)
         {
             ensure_equals(default_quadrant_segments, int(8));
         }

--- a/tests/unit/operation/distance/DistanceOpTest.cpp
+++ b/tests/unit/operation/distance/DistanceOpTest.cpp
@@ -28,14 +28,13 @@ namespace tut
 	// Common data used by tests
 	struct test_distanceop_data
 	{
-		geos::geom::GeometryFactory gf;
 		geos::io::WKTReader wktreader;
 
 		typedef geos::geom::Geometry::AutoPtr GeomPtr;
 		typedef std::auto_ptr<geos::geom::CoordinateSequence> CSPtr;
 
 		test_distanceop_data()
-            : gf(), wktreader(&gf)
+            : wktreader()
 		{}
 	};
 
@@ -462,14 +461,15 @@ namespace tut
 	template<>
 	void object::test<19>()
 	{
+        using geos::geom::GeometryFactory;
         const char* wkb_geom1 = "01060000000100000001030000000100000000000000";
         const char* wkb_geom2 = "010100000000000000000000000000000000000000";
 
         geos::geom::PrecisionModel precision(geos::geom::PrecisionModel::FLOATING);
-        geos::geom::GeometryFactory f(&precision);
+        GeometryFactory::unique_ptr f(GeometryFactory::create(&precision));
         std::istringstream istr1(wkb_geom1);
         std::istringstream istr2(wkb_geom2);
-        geos::io::WKBReader wkb(f);
+        geos::io::WKBReader wkb(*f);
         GeomPtr g1(wkb.readHEX(istr1));
         GeomPtr g2(wkb.readHEX(istr2));
         ensure(g1->isValid());

--- a/tests/unit/operation/intersection/RectangleIntersectionTest.cpp
+++ b/tests/unit/operation/intersection/RectangleIntersectionTest.cpp
@@ -6,7 +6,6 @@
 // geos
 #include <geos/operation/intersection/Rectangle.h>
 #include <geos/operation/intersection/RectangleIntersection.h>
-#include <geos/geom/GeometryFactory.h>
 #include <geos/geom/Geometry.h>
 #include <geos/geom/Polygon.h>
 #include <geos/geom/Point.h>
@@ -27,7 +26,6 @@ namespace tut
     // Common data used by tests
     struct test_rectangleintersectiontest_data
     {
-        geos::geom::GeometryFactory gf;
         geos::io::WKTReader wktreader;
         geos::io::WKTWriter wktwriter;
 
@@ -37,8 +35,7 @@ namespace tut
         typedef geos::operation::intersection::RectangleIntersection RectangleIntersection;
 
         test_rectangleintersectiontest_data()
-          : gf(),
-            wktreader(&gf)
+          : wktreader()
         {
           wktwriter.setTrim(true);
         }

--- a/tests/unit/operation/linemerge/LineMergerTest.cpp
+++ b/tests/unit/operation/linemerge/LineMergerTest.cpp
@@ -30,7 +30,6 @@ namespace tut
     typedef std::vector<geos::geom::Geometry*> GeomVect;
     typedef std::vector<geos::geom::LineString*> LineVect;
 
-    geos::geom::GeometryFactory gf;
     geos::io::WKTReader wktreader;
     geos::io::WKTWriter wktwriter;
 
@@ -42,7 +41,7 @@ namespace tut
     LineVect* mrgGeoms;
 
     test_linemerger_data()
-      : gf(), wktreader(&gf), wktwriter(), mrgGeoms(0)
+      : wktreader(), wktwriter(), mrgGeoms(0)
     {
       wktwriter.setTrim(true);
     }

--- a/tests/unit/operation/linemerge/LineSequencerTest.cpp
+++ b/tests/unit/operation/linemerge/LineSequencerTest.cpp
@@ -30,7 +30,6 @@ namespace tut
     typedef std::vector<geos::geom::Geometry*> GeomVect;
     typedef std::vector<geos::geom::LineString*> LineVect;
 
-    geos::geom::GeometryFactory gf;
     geos::io::WKTReader wktreader;
     geos::io::WKTWriter wktwriter;
 
@@ -40,7 +39,7 @@ namespace tut
     GeomVect inpGeoms;
 
     test_linesequencer_data()
-      : gf(), wktreader(&gf), wktwriter()
+      : wktreader(), wktwriter()
     {
       wktwriter.setTrim(true);
     }

--- a/tests/unit/operation/overlay/snap/GeometrySnapperTest.cpp
+++ b/tests/unit/operation/overlay/snap/GeometrySnapperTest.cpp
@@ -24,16 +24,13 @@ namespace tut
     {
         typedef std::auto_ptr<geos::geom::Geometry> GeomAutoPtr;
 
-        geos::geom::GeometryFactory factory;
-
         geos::io::WKTReader reader;
 
         typedef geos::operation::overlay::snap::GeometrySnapper GeometrySnapper;
 
         test_geometrysnapper_data()
                 :
-                factory(), // initialize before use!
-                reader(&factory)
+                reader()
         {
         }
     };

--- a/tests/unit/operation/overlay/validate/FuzzyPointLocatorTest.cpp
+++ b/tests/unit/operation/overlay/validate/FuzzyPointLocatorTest.cpp
@@ -25,7 +25,6 @@ namespace tut
 	// Common data used by tests
 	struct test_fuzzypointlocator_data
 	{
-		geos::geom::GeometryFactory gf;
 		geos::io::WKTReader wktreader;
 		geos::io::WKBReader wkbreader;
 
@@ -35,9 +34,8 @@ namespace tut
 
 		test_fuzzypointlocator_data()
 			:
-			gf(),
-			wktreader(&gf),
-			wkbreader(gf)
+			wktreader(),
+			wkbreader()
 		{
 			std::string wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
 			g.reset(wktreader.read(wkt));

--- a/tests/unit/operation/overlay/validate/OffsetPointGeneratorTest.cpp
+++ b/tests/unit/operation/overlay/validate/OffsetPointGeneratorTest.cpp
@@ -27,7 +27,7 @@ namespace tut
 	// Common data used by tests
 	struct test_offsetpointgenerator_data
 	{
-		geos::geom::GeometryFactory gf;
+		const geos::geom::GeometryFactory& gf;
 		geos::io::WKTReader wktreader;
 		geos::algorithm::PointLocator locator;
 
@@ -37,7 +37,7 @@ namespace tut
 
 		test_offsetpointgenerator_data()
 			:
-			gf(),
+			gf(*GeometryFactory::getDefaultInstance()),
 			wktreader(&gf)
 		{
 		}

--- a/tests/unit/operation/overlay/validate/OverlayResultValidatorTest.cpp
+++ b/tests/unit/operation/overlay/validate/OverlayResultValidatorTest.cpp
@@ -27,7 +27,6 @@ namespace tut
 	// Common data used by tests
 	struct test_overlayresultvalidator_data
 	{
-		geos::geom::GeometryFactory gf;
 		geos::io::WKTReader wktreader;
 		geos::algorithm::PointLocator locator;
 
@@ -37,8 +36,7 @@ namespace tut
 
 		test_overlayresultvalidator_data()
 			:
-			gf(),
-			wktreader(&gf)
+			wktreader()
 		{
 		}
 

--- a/tests/unit/operation/polygonize/PolygonizeTest.cpp
+++ b/tests/unit/operation/polygonize/PolygonizeTest.cpp
@@ -29,7 +29,6 @@ namespace tut
     // Common data used by tests
     struct test_polygonizetest_data
     {
-        geos::geom::GeometryFactory gf;
         geos::io::WKTReader wktreader;
         geos::io::WKTWriter wktwriter;
 
@@ -39,8 +38,7 @@ namespace tut
         typedef geos::operation::polygonize::Polygonizer Polygonizer;
 
         test_polygonizetest_data()
-          : gf(),
-            wktreader(&gf)
+          : wktreader()
         {
           wktwriter.setTrim(true);
         }

--- a/tests/unit/operation/sharedpaths/SharedPathsOpTest.cpp
+++ b/tests/unit/operation/sharedpaths/SharedPathsOpTest.cpp
@@ -28,7 +28,6 @@ namespace tut
   {
     typedef geos::operation::sharedpaths::SharedPathsOp SharedPathsOp;
 
-    geos::geom::GeometryFactory gf;
     geos::io::WKTReader wktreader;
     geos::io::WKTWriter wktwriter;
 
@@ -38,7 +37,7 @@ namespace tut
     SharedPathsOp::PathList backDir;
 
     test_shpathop_data()
-      : gf(), wktreader(&gf), wktwriter()
+      : wktreader(), wktwriter()
     {
       wktwriter.setTrim(true);
     }

--- a/tests/unit/operation/union/CascadedPolygonUnionTest.cpp
+++ b/tests/unit/operation/union/CascadedPolygonUnionTest.cpp
@@ -25,15 +25,15 @@ namespace tut
     // Common data used by tests
     struct test_cascadedpolygonuniontest_data
     {
-        geos::geom::GeometryFactory gf;
+        const geos::geom::GeometryFactory& gf;
         geos::io::WKTReader wktreader;
         geos::io::WKTWriter wktwriter;
 
         typedef geos::geom::Geometry::AutoPtr GeomPtr;
 
         test_cascadedpolygonuniontest_data()
-          : gf(),
-            wktreader(&gf)
+          : gf(*geos::geom::GeometryFactory::getDefaultInstance())
+          , wktreader(&gf)
         {}
     };
 

--- a/tests/unit/operation/union/UnaryUnionOpTest.cpp
+++ b/tests/unit/operation/union/UnaryUnionOpTest.cpp
@@ -26,7 +26,8 @@ namespace tut
     // Common data used by tests
     struct test_unaryuniontest_data
     {
-        geos::geom::GeometryFactory gf;
+        typedef geos::geom::GeometryFactory GeometryFactory;
+        GeometryFactory::unique_ptr gf;
         geos::io::WKTReader wktreader;
         geos::io::WKTWriter wktwriter;
 
@@ -35,8 +36,8 @@ namespace tut
         typedef geos::operation::geounion::UnaryUnionOp UnaryUnionOp;
 
         test_unaryuniontest_data()
-          : gf(),
-            wktreader(&gf)
+          : gf(GeometryFactory::create()),
+            wktreader(gf.get())
         {
           wktwriter.setTrim(true);
         }
@@ -85,7 +86,7 @@ namespace tut
 
           GeomPtr result;
           if ( geoms.empty() )
-            result = UnaryUnionOp::Union(geoms, gf);
+            result = UnaryUnionOp::Union(geoms, *gf);
           else
             result = UnaryUnionOp::Union(geoms);
 

--- a/tests/unit/operation/valid/IsValidTest.cpp
+++ b/tests/unit/operation/valid/IsValidTest.cpp
@@ -33,12 +33,13 @@ namespace tut
     struct test_isvalidop_data
     {
 	typedef std::auto_ptr<Geometry> GeomPtr;
+        typedef geos::geom::GeometryFactory GeometryFactory;
 
         geos::geom::PrecisionModel pm_;
-        geos::geom::GeometryFactory factory_;
+        GeometryFactory::unique_ptr factory_;
 
         test_isvalidop_data()
-			: pm_(1), factory_(&pm_, 0)
+			: pm_(1), factory_(GeometryFactory::create(&pm_, 0))
         {}
     };
 
@@ -59,7 +60,7 @@ namespace tut
 	CoordinateSequence* cs = new CoordinateArraySequence();
 	cs->add(Coordinate(0.0, 0.0));
 	cs->add(Coordinate(1.0, DoubleNotANumber));
-	GeomPtr line ( factory_.createLineString(cs) );
+	GeomPtr line ( factory_->createLineString(cs) );
 
 
 	IsValidOp isValidOp(line.get());

--- a/tests/unit/operation/valid/ValidClosedRingTest.cpp
+++ b/tests/unit/operation/valid/ValidClosedRingTest.cpp
@@ -38,13 +38,16 @@ namespace tut
     struct test_validclosedring_data
     {
 	typedef std::auto_ptr<Geometry> GeomPtr;
+        typedef geos::geom::GeometryFactory GeometryFactory;
 
         geos::geom::PrecisionModel pm_;
-        geos::geom::GeometryFactory factory_;
+        GeometryFactory::unique_ptr factory_;
         geos::io::WKTReader rdr;
 
         test_validclosedring_data()
-			: pm_(1), factory_(&pm_, 0), rdr(&factory_)
+			: pm_(1)
+      , factory_(GeometryFactory::create(&pm_, 0))
+      , rdr(factory_.get())
         {}
 
 	GeomPtr fromWKT(const std::string& wkt)

--- a/tests/unit/operation/valid/ValidSelfTouchingRingFormingHoleTest.cpp
+++ b/tests/unit/operation/valid/ValidSelfTouchingRingFormingHoleTest.cpp
@@ -40,11 +40,14 @@ namespace tut
 	typedef std::auto_ptr<Geometry> GeomPtr;
 
         geos::geom::PrecisionModel pm_;
-        geos::geom::GeometryFactory factory_;
+        typedef geos::geom::GeometryFactory GeometryFactory;
+        geos::geom::GeometryFactory::unique_ptr factory_;
         geos::io::WKTReader rdr;
 
         test_ValidSelfTouchingRingFormingHole_data()
-			: pm_(1), factory_(&pm_, 0), rdr(&factory_)
+      : pm_(1)
+      , factory_(GeometryFactory::create(&pm_, 0))
+      , rdr(factory_.get())
         {}
 
 	GeomPtr fromWKT(const std::string& wkt)

--- a/tests/unit/precision/GeometryPrecisionReducerTest.cpp
+++ b/tests/unit/precision/GeometryPrecisionReducerTest.cpp
@@ -25,11 +25,12 @@ namespace tut
     struct test_gpr_data
     {
         typedef std::auto_ptr<geos::geom::Geometry> GeometryPtr;
+        typedef geos::geom::GeometryFactory GeometryFactory;
 
         geos::geom::PrecisionModel pm_float_;
         geos::geom::PrecisionModel pm_fixed_;
-        geos::geom::GeometryFactory factory_;
-        geos::geom::GeometryFactory factory_fixed_;
+        GeometryFactory::unique_ptr factory_;
+        GeometryFactory::unique_ptr factory_fixed_;
         geos::io::WKTReader reader_;
         geos::precision::GeometryPrecisionReducer reducer_;
         geos::precision::GeometryPrecisionReducer reducerKeepCollapse_; // keep collapse
@@ -38,12 +39,12 @@ namespace tut
         test_gpr_data() :
             pm_float_(),
             pm_fixed_(1),
-            factory_(&pm_float_, 0),
-            factory_fixed_(&pm_fixed_, 0),
-            reader_(&factory_),
+            factory_(GeometryFactory::create(&pm_float_, 0)),
+            factory_fixed_(GeometryFactory::create(&pm_fixed_, 0)),
+            reader_(factory_.get()),
             reducer_(pm_fixed_),
             reducerKeepCollapse_(pm_fixed_),
-            reducerChangePM_(factory_fixed_)
+            reducerChangePM_(*factory_fixed_)
         {
             reducerKeepCollapse_.setRemoveCollapsedComponents(false);
         }
@@ -171,7 +172,7 @@ namespace tut
         GeometryPtr result(reducerChangePM_.reduce(*g1));
 
         ensure( result->equalsExact(g2.get()) );
-        ensure( result->getFactory() == &factory_fixed_ );
+        ensure( result->getFactory() == factory_fixed_.get() );
     }
 
     // Test points with changed PM
@@ -185,7 +186,7 @@ namespace tut
         GeometryPtr result(reducerChangePM_.reduce(*g1));
 
         ensure( result->equalsExact(g2.get()) );
-        ensure( result->getFactory() == &factory_fixed_ );
+        ensure( result->getFactory() == factory_fixed_.get() );
     }
 
 

--- a/tests/unit/precision/SimpleGeometryPrecisionReducerTest.cpp
+++ b/tests/unit/precision/SimpleGeometryPrecisionReducerTest.cpp
@@ -23,10 +23,11 @@ namespace tut
     struct test_sgpr_data
     {
         typedef std::auto_ptr<geos::geom::Geometry> GeometryPtr;
+        typedef geos::geom::GeometryFactory GeometryFactory;
 
         geos::geom::PrecisionModel pm_float_;
         geos::geom::PrecisionModel pm_fixed_;
-        geos::geom::GeometryFactory factory_;
+        GeometryFactory::unique_ptr factory_;
         geos::io::WKTReader reader_;
         geos::precision::SimpleGeometryPrecisionReducer reducer_;
         geos::precision::SimpleGeometryPrecisionReducer reducer2_; // keep collapse
@@ -34,8 +35,8 @@ namespace tut
         test_sgpr_data() :
             pm_float_(),
             pm_fixed_(1),
-            factory_(&pm_float_, 0),
-            reader_(&factory_),
+            factory_(GeometryFactory::create(&pm_float_, 0)),
+            reader_(factory_.get()),
             reducer_(&pm_fixed_),
             reducer2_(&pm_fixed_)
         {

--- a/tests/unit/simplify/DouglasPeuckerSimplifierTest.cpp
+++ b/tests/unit/simplify/DouglasPeuckerSimplifierTest.cpp
@@ -27,8 +27,6 @@ namespace tut
 	// Common data used by tests
 	struct test_dpsimp_data
 	{
-		geos::geom::PrecisionModel pm;
-		geos::geom::GeometryFactory gf;
 		geos::io::WKTReader wktreader;
         geos::io::WKTWriter wktwriter;
 
@@ -36,9 +34,7 @@ namespace tut
 
 		test_dpsimp_data()
 			:
-			pm(geos::geom::PrecisionModel::FLOATING),
-			gf(&pm),
-			wktreader(&gf)
+			wktreader()
 		{}
 	};
 

--- a/tests/unit/simplify/TopologyPreservingSimplifierTest.cpp
+++ b/tests/unit/simplify/TopologyPreservingSimplifierTest.cpp
@@ -28,14 +28,18 @@ namespace tut
 	struct test_tpsimp_data
 	{
 		geos::geom::PrecisionModel pm;
-		geos::geom::GeometryFactory gf;
+		typedef geos::geom::GeometryFactory GeometryFactory;
+		GeometryFactory::unique_ptr gf;
 		geos::io::WKTReader wktreader;
 		geos::io::WKTWriter wktwriter;
 
 		typedef geos::geom::Geometry::AutoPtr GeomPtr;
 
 		test_tpsimp_data()
-            : pm(1.0), gf(&pm), wktreader(&gf), wktwriter()
+            : pm(1.0)
+            , gf(GeometryFactory::create(&pm))
+            , wktreader(gf.get())
+            , wktwriter()
 		{
 			//wktwriter.setTrim(1);
 		}

--- a/tests/unit/triangulate/DelaunayTest.cpp
+++ b/tests/unit/triangulate/DelaunayTest.cpp
@@ -49,7 +49,7 @@ namespace tut
 		Geometry *expected = reader.read(expectedWkt);
 		DelaunayTriangulationBuilder builder;
 		builder.setTolerance(tolerance);
-		GeometryFactory geomFact;
+    const GeometryFactory& geomFact(*GeometryFactory::getDefaultInstance());
 
 		builder.setSites(*sites);
 		if(computeTriangles)
@@ -84,7 +84,7 @@ namespace tut
 		triangulator.insertSite(Vertex(0, 0));
 
 		//extract the triangles from the subdivision
-		GeometryFactory geomFact;
+    const GeometryFactory& geomFact(*GeometryFactory::getDefaultInstance());
 		std::auto_ptr<GeometryCollection> tris = sub.getTriangles(geomFact);
 	}
 

--- a/tests/unit/triangulate/VoronoiTest.cpp
+++ b/tests/unit/triangulate/VoronoiTest.cpp
@@ -52,7 +52,7 @@ namespace tut
 		std::auto_ptr<Geometry> sites ( reader.read(sitesWkt) );
 		std::auto_ptr<Geometry> expected ( reader.read(expectedWkt) );
 		std::auto_ptr<GeometryCollection> results;
-		GeometryFactory geomFact;
+    const GeometryFactory& geomFact(*GeometryFactory::getDefaultInstance());
 		builder.setSites(*sites);
 
 		//set Tolerance:

--- a/tests/unit/triangulate/quadedge/QuadEdgeSubdivisionTest.cpp
+++ b/tests/unit/triangulate/quadedge/QuadEdgeSubdivisionTest.cpp
@@ -37,15 +37,11 @@ namespace tut
 	// dummy data, not used
 	struct test_quadedgesub_data
 	{
-		geos::geom::PrecisionModel pm;
-		geos::geom::GeometryFactory gf;
 		geos::io::WKTReader reader;
 		geos::io::WKTWriter writer;
 		test_quadedgesub_data()
       :
-			pm(),
-			gf(&pm),
-			reader(gf),
+			reader(),
 			writer()
 		{
 			writer.setTrim(true);
@@ -78,8 +74,8 @@ namespace tut
 		ensure(!sub.isOnEdge(e, Coordinate(10, 10)));
 		ensure(!sub.isVertexOfEdge(e, Vertex(10, 10)));
 
-		GeometryFactory geomFact;
-		std::auto_ptr<GeometryCollection> tris = sub.getTriangles(geomFact);
+		GeometryFactory::unique_ptr geomFact(GeometryFactory::create());
+		std::auto_ptr<GeometryCollection> tris = sub.getTriangles(*geomFact);
 		tris.reset();
 		//WKTWriter wkt;
 		//printf("%s\n", wkt.writeFormatted(tris).c_str());
@@ -103,7 +99,7 @@ namespace tut
 		triangulator.insertSites(*vertices);
 
 		//Test for getVoronoiDiagram::
-		GeometryFactory geomFact;
+		const GeometryFactory& geomFact(*GeometryFactory::getDefaultInstance());
 		std::auto_ptr<GeometryCollection> polys = subdiv->getVoronoiDiagram(geomFact);
 		const char *expected_str = "GEOMETRYCOLLECTION (POLYGON ((-5849.974929324658 2268.0517257497568, -4529.9920486948895 2247.139449440667, 221.20588235294116 210.91176470588235, -684.4227119984187 -2848.644297291955, -5849.974929324658 2268.0517257497568)), POLYGON ((212.5 -3774.5, -684.4227119984187 -2848.644297291955, 221.20588235294116 210.91176470588235, 2448.7167655626645 2188.608343256571, 6235.0370264064295 2248.0370264064295, 212.5 -3774.5)), POLYGON ((-4529.9920486948895 2247.139449440667, 2448.7167655626645 2188.608343256571, 221.20588235294116 210.91176470588235, -4529.9920486948895 2247.139449440667)))";
 //		std::cout << polys->toString() << std::endl;
@@ -151,7 +147,7 @@ namespace tut
     triangulator.insertSites(*vertices);
 
     //Test for getVoronoiDiagram::
-    GeometryFactory geomFact;
+		const GeometryFactory& geomFact(*GeometryFactory::getDefaultInstance());
     std::auto_ptr<GeometryCollection> polys = subdiv->getVoronoiDiagram(geomFact);
     for (std::size_t i=0; i<polys->getNumGeometries(); ++i) {
       const Polygon* p = dynamic_cast<const Polygon*>(polys->getGeometryN(i));

--- a/tests/unit/util/UniqueCoordinateArrayFilterTest.cpp
+++ b/tests/unit/util/UniqueCoordinateArrayFilterTest.cpp
@@ -25,13 +25,16 @@ namespace tut
     struct test_uniquecoordinatearrayfilter_data
 	{
 		typedef std::auto_ptr<geos::geom::Geometry> GeometryPtr;
+		typedef geos::geom::GeometryFactory GeometryFactory;
 		
 		geos::geom::PrecisionModel pm_;
-		geos::geom::GeometryFactory factory_;
+		GeometryFactory::unique_ptr factory_;
 		geos::io::WKTReader reader_;
 
 		test_uniquecoordinatearrayfilter_data()
-			: pm_(1), factory_(&pm_, 0), reader_(&factory_)
+			: pm_(1)
+      , factory_(GeometryFactory::create(&pm_, 0))
+      , reader_(factory_.get())
 		{}		
 	};
 

--- a/tests/xmltester/SimpleWKTTester.cpp
+++ b/tests/xmltester/SimpleWKTTester.cpp
@@ -39,7 +39,9 @@ int main(int /*argc*/, char** /*argv*/)
 		ifstream in("WKTIn");
 		string instr;
 		string outstr;
-		WKTReader *r = new WKTReader(new GeometryFactory(new PrecisionModel(),10));
+		PrecisionModel pm;
+    GeometryFactory::unique_ptr gf = GeometryFactory::create(&pm, 10);
+		WKTReader *r = new WKTReader(gf.get());
 		WKTWriter *w = new WKTWriter();
 		Geometry *g;
 

--- a/tests/xmltester/XMLTester.cpp
+++ b/tests/xmltester/XMLTester.cpp
@@ -435,7 +435,7 @@ XMLTester::parseRun(const TiXmlNode* node)
         std::cerr << *curr_file <<": run: Precision Model: " << pm->toString() <<std::endl;
     }
 
-    factory.reset(new geom::GeometryFactory(pm.get()));
+    factory = geom::GeometryFactory::create(pm.get());
     wktreader.reset(new io::WKTReader(factory.get()));
     wktwriter.reset(new io::WKTWriter());
     wkbreader.reset(new io::WKBReader(*factory));

--- a/tests/xmltester/XMLTester.h
+++ b/tests/xmltester/XMLTester.h
@@ -51,7 +51,7 @@ private:
 	geom::Geometry *gT;
 
 	std::auto_ptr<geom::PrecisionModel> pm;
-	std::auto_ptr<geom::GeometryFactory> factory;
+	geom::GeometryFactory::unique_ptr factory;
 	std::auto_ptr<io::WKTReader> wktreader;
 	std::auto_ptr<io::WKTWriter> wktwriter;
 	std::auto_ptr<io::WKBReader> wkbreader;


### PR DESCRIPTION
Only for heap-allocated factories, can be used to give ownership
of the factory to its Geometry childs. Deletion of last child will
destroy the factory.