### PR TITLE
Port MinimumDiameter::getMinimumRectangle algorithm from JTS

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -437,6 +437,18 @@ GEOSConvexHull(const Geometry *g)
 }
 
 Geometry *
+GEOSMinimumRotatedRectangle(const Geometry *g)
+{
+    return GEOSMinimumRotatedRectangle_r( handle, g );
+}
+
+Geometry *
+GEOSMinimumDiameter(const Geometry *g)
+{
+    return GEOSMinimumDiameter_r( handle, g );
+}
+
+Geometry *
 GEOSDifference(const Geometry *g1, const Geometry *g2)
 {
     return GEOSDifference_r( handle, g1, g2 );

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -538,6 +538,10 @@ extern GEOSGeometry GEOS_DLL *GEOSIntersection_r(GEOSContextHandle_t handle,
                                                  const GEOSGeometry* g2);
 extern GEOSGeometry GEOS_DLL *GEOSConvexHull_r(GEOSContextHandle_t handle,
                                                const GEOSGeometry* g);
+extern GEOSGeometry GEOS_DLL *GEOSMinimumRotatedRectangle_r(GEOSContextHandle_t handle,
+                                               const GEOSGeometry* g);
+extern GEOSGeometry GEOS_DLL *GEOSMinimumDiameter_r(GEOSContextHandle_t handle,
+                                               const GEOSGeometry* g);
 extern GEOSGeometry GEOS_DLL *GEOSDifference_r(GEOSContextHandle_t handle,
                                                const GEOSGeometry* g1,
                                                const GEOSGeometry* g2);
@@ -1448,6 +1452,8 @@ extern void GEOS_DLL GEOSGeom_destroy(GEOSGeometry* g);
 extern GEOSGeometry GEOS_DLL *GEOSEnvelope(const GEOSGeometry* g);
 extern GEOSGeometry GEOS_DLL *GEOSIntersection(const GEOSGeometry* g1, const GEOSGeometry* g2);
 extern GEOSGeometry GEOS_DLL *GEOSConvexHull(const GEOSGeometry* g);
+extern GEOSGeometry GEOS_DLL *GEOSMinimumRotatedRectangle(const GEOSGeometry* g);
+extern GEOSGeometry GEOS_DLL *GEOSMinimumDiameter(const GEOSGeometry* g);
 extern GEOSGeometry GEOS_DLL *GEOSDifference(const GEOSGeometry* g1, const GEOSGeometry* g2);
 extern GEOSGeometry GEOS_DLL *GEOSSymDifference(const GEOSGeometry* g1, const GEOSGeometry* g2);
 extern GEOSGeometry GEOS_DLL *GEOSBoundary(const GEOSGeometry* g);

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -43,6 +43,7 @@
 #include <geos/algorithm/distance/DiscreteHausdorffDistance.h>
 #include <geos/algorithm/CGAlgorithms.h>
 #include <geos/algorithm/BoundaryNodeRule.h>
+#include <geos/algorithm/MinimumDiameter.h>
 #include <geos/simplify/DouglasPeuckerSimplifier.h>
 #include <geos/simplify/TopologyPreservingSimplifier.h>
 #include <geos/noding/GeometryNoder.h>
@@ -2006,6 +2007,76 @@ GEOSConvexHull_r(GEOSContextHandle_t extHandle, const Geometry *g1)
     
     return NULL;
 }
+
+
+Geometry *
+GEOSMinimumRotatedRectangle_r(GEOSContextHandle_t extHandle, const Geometry *g)
+{
+    if ( 0 == extHandle )
+    {
+        return NULL;
+    }
+
+    GEOSContextHandleInternal_t *handle = 0;
+    handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+    if ( 0 == handle->initialized )
+    {
+        return NULL;
+    }
+
+    try
+    {
+        geos::algorithm::MinimumDiameter m(g);
+
+        Geometry *g3 = m.getMinimumRectangle();
+        return g3;
+    }
+    catch (const std::exception &e)
+    {
+        handle->ERROR_MESSAGE("%s", e.what());
+    }
+    catch (...)
+    {
+        handle->ERROR_MESSAGE("Unknown exception thrown");
+    }
+
+    return NULL;
+}
+
+Geometry *
+GEOSMinimumDiameter_r(GEOSContextHandle_t extHandle, const Geometry *g)
+{
+    if ( 0 == extHandle )
+    {
+        return NULL;
+    }
+
+    GEOSContextHandleInternal_t *handle = 0;
+    handle = reinterpret_cast<GEOSContextHandleInternal_t*>(extHandle);
+    if ( 0 == handle->initialized )
+    {
+        return NULL;
+    }
+
+    try
+    {
+        geos::algorithm::MinimumDiameter m(g);
+
+        Geometry *g3 = m.getDiameter();
+        return g3;
+    }
+    catch (const std::exception &e)
+    {
+        handle->ERROR_MESSAGE("%s", e.what());
+    }
+    catch (...)
+    {
+        handle->ERROR_MESSAGE("Unknown exception thrown");
+    }
+
+    return NULL;
+}
+
 
 Geometry *
 GEOSDifference_r(GEOSContextHandle_t extHandle, const Geometry *g1, const Geometry *g2)

--- a/include/geos/algorithm/MinimumDiameter.h
+++ b/include/geos/algorithm/MinimumDiameter.h
@@ -11,6 +11,10 @@
  * by the Free Software Foundation. 
  * See the COPYING file for more information.
  *
+ **********************************************************************
+ *
+ * Last port: algorithm/MinimumDiameter.java r966
+ *
  **********************************************************************/
 
 #ifndef GEOS_ALGORITHM_MINIMUMDIAMETER_H
@@ -47,6 +51,13 @@ namespace algorithm { // geos::algorithm
  * The first step in the algorithm is computing the convex hull of the Geometry.
  * If the input Geometry is known to be convex, a hint can be supplied to
  * avoid this computation.
+ * <p>
+ * This class can also be used to compute a line segment representing
+ * the minimum diameter, the supporting line segment of the minimum diameter,
+ * and a minimum rectangle enclosing the input geometry.
+ * This rectangle will
+ * have width equal to the minimum diameter, and have one side
+ * parallel to the supporting segment.
  *
  * @see ConvexHull
  *
@@ -55,6 +66,9 @@ class GEOS_DLL MinimumDiameter {
 private:
 	const geom::Geometry* inputGeom;
 	bool isConvex;
+
+	geom::CoordinateSequence* convexHullPts;
+
 	geom::LineSegment* minBaseSeg;
 	geom::Coordinate* minWidthPt;
 	int minPtIndex;
@@ -76,6 +90,10 @@ private:
 
 	static unsigned int getNextIndex(const geom::CoordinateSequence* pts,
 		unsigned int index);
+
+	static double computeC(double a, double b, const geom::Coordinate &p);
+
+	static geom::LineSegment computeSegmentForLine(double a, double b, double c);
 
 public:
 	~MinimumDiameter();
@@ -126,6 +144,33 @@ public:
 	 * @return a LineString which is a minimum diameter
 	 */
 	geom::LineString* getDiameter();
+
+	/**
+	 * Gets the minimum rectangular Polygon which encloses the input geometry. The rectangle has width
+	 * equal to the minimum diameter, and a longer length. If the convex hill of the input is degenerate
+	 * (a line or point) a LineString or Point is returned.
+	 * The minimum rectangle can be used as an extremely generalized representation for the given
+	 * geometry.
+	 *
+	 * @return the minimum rectangle enclosing the input (or a line or point if degenerate)
+	 */
+	geom::Geometry* getMinimumRectangle();
+
+	/**
+	 * Gets the minimum rectangle enclosing a geometry.
+	 *
+	 * @param geom the geometry
+	 * @return the minimum rectangle enclosing the geometry
+	*/
+	static geom::Geometry* getMinimumRectangle(geom::Geometry* geom);
+
+	/**
+	 * Gets the length of the minimum diameter enclosing a geometry
+	 * @param geom the geometry
+	 * @return the length of the minimum diameter of the geometry
+	 */
+	static geom::Geometry* getMinimumDiameter(geom::Geometry* geom);
+
 };
 
 } // namespace geos::algorithm

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -41,6 +41,7 @@ geos_unit_SOURCES = \
 	algorithm/CGAlgorithms/signedAreaTest.cpp \
 	algorithm/ConvexHullTest.cpp \
 	algorithm/distance/DiscreteHausdorffDistanceTest.cpp \
+	algorithm/MinimumDiameterTest.cpp \
 	algorithm/PointLocatorTest.cpp \
 	algorithm/RobustLineIntersectionTest.cpp \
 	algorithm/RobustLineIntersectorTest.cpp \
@@ -130,6 +131,8 @@ geos_unit_SOURCES = \
 	capi/GEOSInterruptTest.cpp \
 	capi/GEOSIntersectsTest.cpp \
 	capi/GEOSIntersectionTest.cpp \
+	capi/GEOSMinimumRectangleTest.cpp \
+	capi/GEOSMinimumDiameterTest.cpp \
 	capi/GEOSNearestPointsTest.cpp \
 	capi/GEOSWithinTest.cpp \
 	capi/GEOSSimplifyTest.cpp \

--- a/tests/unit/algorithm/MinimumDiameterTest.cpp
+++ b/tests/unit/algorithm/MinimumDiameterTest.cpp
@@ -1,0 +1,236 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2015      Nyall Dawson <nyall dot dawson at gmail dot com>
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************/
+
+//
+// Test Suite for geos::algorithm::MinimumDiameter
+
+#include <tut.hpp>
+// geos
+#include <geos/geom/Coordinate.h>
+#include <geos/algorithm/MinimumDiameter.h>
+#include <geos/io/WKTReader.h>
+#include <geos/io/WKTWriter.h>
+#include <geos/geom/Geometry.h>
+// std
+#include <sstream>
+#include <string>
+#include <memory>
+
+namespace tut
+{
+    //
+    // Test Group
+    //
+
+    // dummy data, not used
+    struct test_minimumdiameter_data {
+      typedef geos::geom::Geometry Geometry;
+      typedef std::auto_ptr<geos::geom::Geometry> GeomPtr;
+
+      typedef geos::geom::Coordinate Coordinate;
+      typedef geos::algorithm::MinimumDiameter MinimumDiameter;
+
+      geos::io::WKTReader reader;
+      std::auto_ptr<Geometry> geom;
+
+      test_minimumdiameter_data()
+      {}
+
+    };
+
+    typedef test_group<test_minimumdiameter_data> group;
+    typedef group::object object;
+
+    group test_minimumdiameter_data_group("geos::algorithm::MinimumDiameter");
+
+    //
+    // Test Cases
+    //
+
+    // Test of getMinimumRectangle
+    template<>
+    template<>
+    void object::test<1>()
+    {
+        GeomPtr geom(reader.read("POLYGON ((0 0, 0 20, 20 20, 20 0, 0 0))"));
+        ensure(0 != geom.get());
+
+        geos::algorithm::MinimumDiameter m(geom.get());
+        GeomPtr minRect( m.getMinimumRectangle() );
+        ensure(0 != minRect.get());
+
+        GeomPtr expectedGeom(reader.read("POLYGON ((0 0, 20 0, 20 20, 0 20, 0 0))"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minRect.get()->equalsExact(expectedGeom.get()) );
+    }
+
+    // Test with expected rotated rectangle
+    template<>
+    template<>
+    void object::test<2>()
+    {
+        GeomPtr geom(reader.read("POLYGON ((0 5, 5 10, 10 5, 5 0, 0 5))"));
+        ensure(0 != geom.get());
+
+        geos::algorithm::MinimumDiameter m(geom.get());
+        GeomPtr minRect( m.getMinimumRectangle() );
+        ensure(0 != minRect.get());
+
+        GeomPtr expectedGeom(reader.read("POLYGON ((5 0, 10 5, 5 10, 0 5, 5 0))"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minRect.get()->equalsExact(expectedGeom.get()) );
+    }
+
+    // Test with EMPTY input
+    template<>
+    template<>
+    void object::test<3>()
+    {
+        GeomPtr geom(reader.read("POLYGON EMPTY"));
+        ensure(0 != geom.get());
+
+        geos::algorithm::MinimumDiameter m(geom.get());
+        GeomPtr minRect( m.getMinimumRectangle() );
+        ensure(0 != minRect.get());
+
+        GeomPtr expectedGeom(reader.read("POLYGON EMPTY"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minRect.get()->equalsExact(expectedGeom.get()) );
+    }
+
+    // Test with Point input
+    template<>
+    template<>
+    void object::test<4>()
+    {
+        GeomPtr geom(reader.read("Point(1 2)"));
+        ensure(0 != geom.get());
+
+        geos::algorithm::MinimumDiameter m(geom.get());
+        GeomPtr minRect( m.getMinimumRectangle() );
+        ensure(0 != minRect.get());
+
+        GeomPtr expectedGeom(reader.read("Point(1 2)"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minRect.get()->equalsExact(expectedGeom.get()) );
+    }
+
+    // Test with LineString input
+    template<>
+    template<>
+    void object::test<5>()
+    {
+        GeomPtr geom(reader.read("LineString(1 2, 2 4)"));
+        ensure(0 != geom.get());
+
+        geos::algorithm::MinimumDiameter m(geom.get());
+        GeomPtr minRect( m.getMinimumRectangle() );
+        ensure(0 != minRect.get());
+
+        GeomPtr expectedGeom(reader.read("LineString(1 2, 2 4)"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minRect.get()->equalsExact(expectedGeom.get()) );
+    }
+
+    // Test minimumDiameter with Point input
+    template<>
+    template<>
+    void object::test<6>()
+    {
+        GeomPtr geom(reader.read("POINT (0 240)"));
+        ensure(0 != geom.get());
+
+        GeomPtr minDiameter( geos::algorithm::MinimumDiameter::getMinimumDiameter( geom.get() ) );
+        ensure(0 != minDiameter.get());
+
+        GeomPtr expectedGeom(reader.read("LineString (0 240, 0 240)"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minDiameter.get()->equalsExact(expectedGeom.get()) );
+    }
+
+    // Test minimumDiameter with LineString input
+    template<>
+    template<>
+    void object::test<7>()
+    {
+        GeomPtr geom(reader.read("LINESTRING (0 240, 220 240)"));
+        ensure(0 != geom.get());
+
+        GeomPtr minDiameter( geos::algorithm::MinimumDiameter::getMinimumDiameter( geom.get() ) );
+        ensure(0 != minDiameter.get());
+
+        GeomPtr expectedGeom(reader.read("LINESTRING (0 240, 0 240)"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minDiameter.get()->equalsExact(expectedGeom.get()) );
+    }
+
+    // Test minimumDiameter with Polygon input
+    template<>
+    template<>
+    void object::test<8>()
+    {
+        GeomPtr geom(reader.read("POLYGON ((0 240, 220 240, 220 0, 0 0, 0 240))"));
+        ensure(0 != geom.get());
+
+        GeomPtr minDiameter( geos::algorithm::MinimumDiameter::getMinimumDiameter( geom.get() ) );
+        ensure(0 != minDiameter.get());
+
+        GeomPtr expectedGeom(reader.read("LINESTRING (0 0, 220 0)"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minDiameter.get()->equalsExact(expectedGeom.get()) );
+    }
+
+    // Test minimumDiameter with Polygon input
+    template<>
+    template<>
+    void object::test<9>()
+    {
+        GeomPtr geom(reader.read("POLYGON ((0 240, 160 140, 220 0, 0 0, 0 240))"));
+        ensure(0 != geom.get());
+
+        GeomPtr minDiameter( geos::algorithm::MinimumDiameter::getMinimumDiameter( geom.get() ) );
+        ensure(0 != minDiameter.get());
+
+        GeomPtr expectedGeom(reader.read("LINESTRING (185.86206896551724 79.65517241379311, 0 0)"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minDiameter.get()->equalsExact(expectedGeom.get(), 0.00000000001) );
+    }
+
+    // Test minimumDiameter with complex LineString
+    template<>
+    template<>
+    void object::test<10>()
+    {
+        GeomPtr geom(reader.read("LINESTRING ( 39 119, 162 197, 135 70, 95 35, 33 66, 111 82, 97 131, 48 160, -4 182, 57 195, 94 202, 90 174, 75 134, 47 114, 0 100, 59 81, 123 60, 136 43, 163 75, 145 114, 93 136, 92 159, 105 175 )"));
+        ensure(0 != geom.get());
+
+        GeomPtr minDiameter( geos::algorithm::MinimumDiameter::getMinimumDiameter( geom.get() ) );
+        ensure(0 != minDiameter.get());
+
+        GeomPtr expectedGeom(reader.read("LINESTRING (64.46262341325811 196.41184767277855, 95 35)"));
+        ensure(0 != expectedGeom.get());
+
+        ensure( minDiameter.get()->equalsExact(expectedGeom.get(), 0.00000000001) );
+    }
+
+} // namespace tut

--- a/tests/unit/capi/GEOSMinimumDiameterTest.cpp
+++ b/tests/unit/capi/GEOSMinimumDiameterTest.cpp
@@ -1,0 +1,83 @@
+//
+// Test Suite for C-API GEOSMinimumDiameter
+#include <tut.hpp>
+// geos
+#include <geos_c.h>
+// std
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+
+namespace tut
+{
+    //
+    // Test Group
+    //
+
+    // Common data used in test cases.
+    struct test_capigeosminimumdiameter_data
+    {
+        GEOSGeometry* input_;
+        GEOSWKTWriter* wktw_;
+        char* wkt_;
+
+        static void notice(const char *fmt, ...)
+        {
+            std::fprintf( stdout, "NOTICE: ");
+
+            va_list ap;
+            va_start(ap, fmt);
+            std::vfprintf(stdout, fmt, ap);
+            va_end(ap);
+
+            std::fprintf(stdout, "\n");
+        }
+
+        test_capigeosminimumdiameter_data()
+            : input_(0), wkt_(0)
+        {
+            initGEOS(notice, notice);
+            wktw_ = GEOSWKTWriter_create();
+            GEOSWKTWriter_setTrim(wktw_, 1);
+            GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
+        }
+
+        ~test_capigeosminimumdiameter_data()
+        {
+            GEOSGeom_destroy(input_);
+            input_ = 0;
+            GEOSWKTWriter_destroy(wktw_);
+            GEOSFree(wkt_);
+            wkt_ = 0;
+            finishGEOS();
+        }
+
+    };
+
+    typedef test_group<test_capigeosminimumdiameter_data> group;
+    typedef group::object object;
+
+    group test_capigeosminimumdiameter_group("capi::GEOSMinimumDiameter");
+
+    //
+    // Test Cases
+    //
+
+    template<>
+    template<>
+    void object::test<1>()
+    {
+        input_ = GEOSGeomFromWKT("POLYGON ((0 0, 0 15, 5 10, 5 0, 0 0))");
+        ensure( 0 != input_ );
+
+        GEOSGeometry* output = GEOSMinimumDiameter(input_);
+        ensure( 0 != output );
+        ensure( 0 == GEOSisEmpty(output) );
+
+        wkt_ = GEOSWKTWriter_write(wktw_, output);
+        ensure_equals(std::string(wkt_), std::string( "LINESTRING (0 0, 5 0)"));
+
+        GEOSGeom_destroy(output);
+    }
+
+} // namespace tut

--- a/tests/unit/capi/GEOSMinimumRectangleTest.cpp
+++ b/tests/unit/capi/GEOSMinimumRectangleTest.cpp
@@ -1,0 +1,84 @@
+//
+// Test Suite for C-API GEOSMinimumRotatedRectangle
+
+#include <tut.hpp>
+// geos
+#include <geos_c.h>
+// std
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+
+namespace tut
+{
+    //
+    // Test Group
+    //
+
+    // Common data used in test cases.
+    struct test_capigeosminimumrectangle_data
+    {
+        GEOSGeometry* input_;
+        GEOSWKTWriter* wktw_;
+        char* wkt_;
+
+        static void notice(const char *fmt, ...)
+        {
+            std::fprintf( stdout, "NOTICE: ");
+
+            va_list ap;
+            va_start(ap, fmt);
+            std::vfprintf(stdout, fmt, ap);
+            va_end(ap);
+
+            std::fprintf(stdout, "\n");
+        }
+
+        test_capigeosminimumrectangle_data()
+            : input_(0), wkt_(0)
+        {
+            initGEOS(notice, notice);
+            wktw_ = GEOSWKTWriter_create();
+            GEOSWKTWriter_setTrim(wktw_, 1);
+            GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
+        }
+
+        ~test_capigeosminimumrectangle_data()
+        {
+            GEOSGeom_destroy(input_);
+            input_ = 0;
+            GEOSWKTWriter_destroy(wktw_);
+            GEOSFree(wkt_);
+            wkt_ = 0;
+            finishGEOS();
+        }
+
+    };
+
+    typedef test_group<test_capigeosminimumrectangle_data> group;
+    typedef group::object object;
+
+    group test_capigeosminimumrectangle_group("capi::GEOSMinimumRotatedRectangle");
+
+    //
+    // Test Cases
+    //
+
+    template<>
+    template<>
+    void object::test<1>()
+    {
+        input_ = GEOSGeomFromWKT("POLYGON ((1 6, 6 11, 11 6, 6 1, 1 6))");
+        ensure( 0 != input_ );
+
+        GEOSGeometry* output = GEOSMinimumRotatedRectangle(input_);
+        ensure( 0 != output );
+        ensure( 0 == GEOSisEmpty(output) );
+
+        wkt_ = GEOSWKTWriter_write(wktw_, output);
+        ensure_equals(std::string(wkt_), std::string( "POLYGON ((6 1, 11 6, 6 11, 1 6, 6 1))"));
+
+        GEOSGeom_destroy(output);
+    }
+
+} // namespace tut


### PR DESCRIPTION
This commit ports the JTS MinimumDiameter::getMinimumRectangle algorithm and adds it to the c API. 

I've tried to model the code as much as possible off the existing algorithms/unit tests, but this is my first contribution to GEOS (hopefully many more to come!) and I may be unaware of what's considered best-practice here.

