### PR TITLE
Fix incorrect logic in Vertex::classify

### DIFF
--- a/include/geos/triangulate/quadedge/Vertex.h
+++ b/include/geos/triangulate/quadedge/Vertex.h
@@ -12,7 +12,7 @@
  *
  **********************************************************************
  *
- * Last port: triangulate/quadedge/Vertex.java r524
+ * Last port: triangulate/quadedge/Vertex.java r705
  *
  **********************************************************************/
 
@@ -248,7 +248,17 @@ private:
 			const Vertex &v2) const;
 
 	/**
-	 * Interpolates the Z value of a point enclosed in a 3D triangle.
+	 * Interpolates the Z-value (height) of a point enclosed in a triangle
+	 * whose vertices all have Z values.
+	 * The containing triangle must not be degenerate
+	 * (in other words, the three vertices must enclose a
+	 * non-zero area).
+	 *
+	 * @param p the point to interpolate the Z value of
+	 * @param v0 a vertex of a triangle containing the p
+	 * @param v1 a vertex of a triangle containing the p
+	 * @param v2 a vertex of a triangle containing the p
+	 * @return the interpolated Z-value (height) of the point
 	 */
 	static double interpolateZ(const geom::Coordinate &p, const geom::Coordinate &v0, 
 			const geom::Coordinate &v1, const geom::Coordinate &v2);
@@ -259,7 +269,7 @@ private:
 	 * @param p
 	 * @param p0
 	 * @param p1
-	 * @return
+	 * @return the interpolated Z value
 	 */
 	static double interpolateZ(const geom::Coordinate &p, const geom::Coordinate &p0, 
 			const geom::Coordinate &p1);

--- a/src/triangulate/quadedge/Vertex.cpp
+++ b/src/triangulate/quadedge/Vertex.cpp
@@ -12,7 +12,7 @@
  *
  **********************************************************************
  *
- * Last port: triangulate/Vertex.java r524
+ * Last port: triangulate/Vertex.java r705
  *
  **********************************************************************/
 
@@ -51,24 +51,21 @@ int Vertex::classify(const Vertex &p0, const Vertex &p1)
 	std::auto_ptr<Vertex> a = p1.sub(p0);
 	std::auto_ptr<Vertex> b = p2.sub(p0);
 	double sa = a->crossProduct(*b);
-	int ret;
 
 	if (sa > 0.0)
-		ret =  LEFT;
+		return LEFT;
 	if (sa < 0.0)
-		ret =  RIGHT;
+		return RIGHT;
 	if ((a->getX() * b->getX() < 0.0) || (a->getY() * b->getY() < 0.0))
-		ret =  BEHIND;
+		return BEHIND;
 	if (a->magn() < b->magn())
-		ret =  BEYOND;
+		return BEYOND;
 	if (p0.equals(p2))
-		ret =  ORIGIN;
+		return ORIGIN;
 	if (p1.equals(p2))
-		ret =  DESTINATION;
+		return DESTINATION;
 	else
-		ret =  BETWEEN;
-
-	return ret;
+		return BETWEEN;
 }
 
 bool Vertex::isInCircle(const Vertex &a, const Vertex &b, const Vertex &c) const


### PR DESCRIPTION
As identified by a Coverity scan over GEOS, Vertex::classify always returns either DESTINATION or BETWEEN due to incorrect logic. 

This PR fixes the logic (restoring it to JTS behaviour), and also syncs Vertex.cpp/.h to r705 (brings in documentation improvements)

