### PR TITLE
Rename GEOSMinimumDiameter to GEOSMinimumWidth, add docs

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -443,9 +443,9 @@ GEOSMinimumRotatedRectangle(const Geometry *g)
 }
 
 Geometry *
-GEOSMinimumDiameter(const Geometry *g)
+GEOSMinimumWidth(const Geometry *g)
 {
-    return GEOSMinimumDiameter_r( handle, g );
+    return GEOSMinimumWidth_r( handle, g );
 }
 
 Geometry *

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -538,10 +538,24 @@ extern GEOSGeometry GEOS_DLL *GEOSIntersection_r(GEOSContextHandle_t handle,
                                                  const GEOSGeometry* g2);
 extern GEOSGeometry GEOS_DLL *GEOSConvexHull_r(GEOSContextHandle_t handle,
                                                const GEOSGeometry* g);
+
+/* Returns the minimum rotated rectangular POLYGON which encloses the input geometry. The rectangle
+ * has width equal to the minimum diameter, and a longer length. If the convex hill of the input is
+ * degenerate (a line or point) a LINESTRING or POINT is returned. The minimum rotated rectangle can
+ * be used as an extremely generalized representation for the given geometry.
+ */
 extern GEOSGeometry GEOS_DLL *GEOSMinimumRotatedRectangle_r(GEOSContextHandle_t handle,
                                                const GEOSGeometry* g);
-extern GEOSGeometry GEOS_DLL *GEOSMinimumDiameter_r(GEOSContextHandle_t handle,
+
+/* Returns a LINESTRING geometry which represents the minimum diameter of the geometry.
+ * The minimum diameter is defined to be the width of the smallest band that
+ * contains the geometry, where a band is a strip of the plane defined
+ * by two parallel lines. This can be thought of as the smallest hole that the geometry
+ * can be moved through, with a single rotation.
+ */
+extern GEOSGeometry GEOS_DLL *GEOSMinimumWidth_r(GEOSContextHandle_t handle,
                                                const GEOSGeometry* g);
+
 extern GEOSGeometry GEOS_DLL *GEOSDifference_r(GEOSContextHandle_t handle,
                                                const GEOSGeometry* g1,
                                                const GEOSGeometry* g2);
@@ -1452,8 +1466,22 @@ extern void GEOS_DLL GEOSGeom_destroy(GEOSGeometry* g);
 extern GEOSGeometry GEOS_DLL *GEOSEnvelope(const GEOSGeometry* g);
 extern GEOSGeometry GEOS_DLL *GEOSIntersection(const GEOSGeometry* g1, const GEOSGeometry* g2);
 extern GEOSGeometry GEOS_DLL *GEOSConvexHull(const GEOSGeometry* g);
+
+/* Returns the minimum rotated rectangular POLYGON which encloses the input geometry. The rectangle
+ * has width equal to the minimum diameter, and a longer length. If the convex hill of the input is
+ * degenerate (a line or point) a LINESTRING or POINT is returned. The minimum rotated rectangle can
+ * be used as an extremely generalized representation for the given geometry.
+ */
 extern GEOSGeometry GEOS_DLL *GEOSMinimumRotatedRectangle(const GEOSGeometry* g);
-extern GEOSGeometry GEOS_DLL *GEOSMinimumDiameter(const GEOSGeometry* g);
+
+/* Returns a LINESTRING geometry which represents the minimum diameter of the geometry.
+ * The minimum diameter is defined to be the width of the smallest band that
+ * contains the geometry, where a band is a strip of the plane defined
+ * by two parallel lines. This can be thought of as the smallest hole that the geometry
+ * can be moved through, with a single rotation.
+ */
+extern GEOSGeometry GEOS_DLL *GEOSMinimumWidth(const GEOSGeometry* g);
+
 extern GEOSGeometry GEOS_DLL *GEOSDifference(const GEOSGeometry* g1, const GEOSGeometry* g2);
 extern GEOSGeometry GEOS_DLL *GEOSSymDifference(const GEOSGeometry* g1, const GEOSGeometry* g2);
 extern GEOSGeometry GEOS_DLL *GEOSBoundary(const GEOSGeometry* g);

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -2044,7 +2044,7 @@ GEOSMinimumRotatedRectangle_r(GEOSContextHandle_t extHandle, const Geometry *g)
 }
 
 Geometry *
-GEOSMinimumDiameter_r(GEOSContextHandle_t extHandle, const Geometry *g)
+GEOSMinimumWidth_r(GEOSContextHandle_t extHandle, const Geometry *g)
 {
     if ( 0 == extHandle )
     {

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -132,7 +132,7 @@ geos_unit_SOURCES = \
 	capi/GEOSIntersectsTest.cpp \
 	capi/GEOSIntersectionTest.cpp \
 	capi/GEOSMinimumRectangleTest.cpp \
-	capi/GEOSMinimumDiameterTest.cpp \
+	capi/GEOSMinimumWidthTest.cpp \
 	capi/GEOSNearestPointsTest.cpp \
 	capi/GEOSWithinTest.cpp \
 	capi/GEOSSimplifyTest.cpp \

--- a/tests/unit/capi/GEOSMinimumWidthTest.cpp
+++ b/tests/unit/capi/GEOSMinimumWidthTest.cpp
@@ -1,5 +1,5 @@
 //
-// Test Suite for C-API GEOSMinimumDiameter
+// Test Suite for C-API GEOSMinimumWidth
 #include <tut.hpp>
 // geos
 #include <geos_c.h>
@@ -15,7 +15,7 @@ namespace tut
     //
 
     // Common data used in test cases.
-    struct test_capigeosminimumdiameter_data
+    struct test_capigeosminimumwidth_data
     {
         GEOSGeometry* input_;
         GEOSWKTWriter* wktw_;
@@ -33,7 +33,7 @@ namespace tut
             std::fprintf(stdout, "\n");
         }
 
-        test_capigeosminimumdiameter_data()
+        test_capigeosminimumwidth_data()
             : input_(0), wkt_(0)
         {
             initGEOS(notice, notice);
@@ -42,7 +42,7 @@ namespace tut
             GEOSWKTWriter_setRoundingPrecision(wktw_, 8);
         }
 
-        ~test_capigeosminimumdiameter_data()
+        ~test_capigeosminimumwidth_data()
         {
             GEOSGeom_destroy(input_);
             input_ = 0;
@@ -54,10 +54,10 @@ namespace tut
 
     };
 
-    typedef test_group<test_capigeosminimumdiameter_data> group;
+    typedef test_group<test_capigeosminimumwidth_data> group;
     typedef group::object object;
 
-    group test_capigeosminimumdiameter_group("capi::GEOSMinimumDiameter");
+    group test_capigeosminimumwidth_group("capi::GEOSMinimumWidth");
 
     //
     // Test Cases
@@ -70,7 +70,7 @@ namespace tut
         input_ = GEOSGeomFromWKT("POLYGON ((0 0, 0 15, 5 10, 5 0, 0 0))");
         ensure( 0 != input_ );
 
-        GEOSGeometry* output = GEOSMinimumDiameter(input_);
+        GEOSGeometry* output = GEOSMinimumWidth(input_);
         ensure( 0 != output );
         ensure( 0 == GEOSisEmpty(output) );
 


### PR DESCRIPTION
As discussed on https://github.com/libgeos/libgeos/pull/54, this renames GEOSMinimumDiameter to GEOSMinimumWidth

I've also added docs to the c headers for these new methods.