### PR TITLE
Trac #768 - Add GEOSSTRtree_nearest to CAPI

### DIFF
--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -1146,12 +1146,20 @@ GEOSSTRtree_query (geos::index::strtree::STRtree *tree,
     GEOSSTRtree_query_r( handle, tree, g, cb, userdata );
 }
 
-const void *
+const GEOSGeometry *
 GEOSSTRtree_nearest (geos::index::strtree::STRtree *tree,
-                     const geos::geom::Geometry *g,
-                     int (*distancefn)(const void* item1, const void* item2, double* distance))
+                     const geos::geom::Geometry *g)
 {
-    return GEOSSTRtree_nearest_r( handle, tree, g, distancefn);
+    return (const GEOSGeometry*) GEOSSTRtree_nearest_generic( tree, g, g, NULL, NULL);
+}
+
+const void* GEOSSTRtree_nearest_generic(GEOSSTRtree *tree,
+                                        const void* item,
+                                        const GEOSGeometry* itemEnvelope,
+                                        int (*distancefn)(const void* item1, const void* item2, double* distance, void* userdata),
+                                        void* userdata)
+{
+    return GEOSSTRtree_nearest_generic_r( handle, tree, item, itemEnvelope, distancefn, userdata);
 }
 
 void

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -1146,6 +1146,14 @@ GEOSSTRtree_query (geos::index::strtree::STRtree *tree,
     GEOSSTRtree_query_r( handle, tree, g, cb, userdata );
 }
 
+const void *
+GEOSSTRtree_nearest (geos::index::strtree::STRtree *tree,
+                     const geos::geom::Geometry *g,
+                     int (*distancefn)(const void* item1, const void* item2, double* distance))
+{
+    return GEOSSTRtree_nearest_r( handle, tree, g, distancefn);
+}
+
 void
 GEOSSTRtree_iterate(geos::index::strtree::STRtree *tree,
                     GEOSQueryCallback callback,

--- a/capi/geos_c.cpp
+++ b/capi/geos_c.cpp
@@ -1156,7 +1156,7 @@ GEOSSTRtree_nearest (geos::index::strtree::STRtree *tree,
 const void* GEOSSTRtree_nearest_generic(GEOSSTRtree *tree,
                                         const void* item,
                                         const GEOSGeometry* itemEnvelope,
-                                        int (*distancefn)(const void* item1, const void* item2, double* distance, void* userdata),
+                                        GEOSDistanceCallback distancefn,
                                         void* userdata)
 {
     return GEOSSTRtree_nearest_generic_r( handle, tree, item, itemEnvelope, distancefn, userdata);

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -814,10 +814,19 @@ extern void GEOS_DLL GEOSSTRtree_query_r(GEOSContextHandle_t handle,
                                          const GEOSGeometry *g,
                                          GEOSQueryCallback callback,
                                          void *userdata);
+
 extern const void* GEOS_DLL GEOSSTRtree_nearest_r(GEOSContextHandle_t handle,
+                                                  GEOSSTRtree *tree,
+                                                  const GEOSGeometry* geom);
+
+
+extern const void* GEOS_DLL GEOSSTRtree_nearest_generic_r(GEOSContextHandle_t handle,
                                                           GEOSSTRtree *tree,
-                                                          const GEOSGeometry* g,
-                                                          int (*distancefn)(const void* item1, const void* item2, double* distance));
+                                                          const void* item,
+                                                          const GEOSGeometry* itemEnvelope,
+                                                          int (*distancefn)(const void* item1, const void* item2, double* distance, void* userdata),
+                                                          void* userdata);
+
 extern void GEOS_DLL GEOSSTRtree_iterate_r(GEOSContextHandle_t handle,
                                        GEOSSTRtree *tree,
                                        GEOSQueryCallback callback,
@@ -1655,20 +1664,92 @@ extern char GEOS_DLL GEOSPreparedWithin(const GEOSPreparedGeometry* pg1, const G
  * GEOSGeometry ownership is retained by caller
  */
 
+/*
+ * Create a new R-tree using the Sort-Tile-Recursive algorithm (STRtree) for two-dimensional
+ * spatial data.
+ *
+ * @param nodeCapacity the maximum number of child nodes that a node may have.  The minimum
+ *            recommended capacity value is 4.  If unsure, use a default node capacity of 10.
+ * @return a pointer to the created tree
+ */
 extern GEOSSTRtree GEOS_DLL *GEOSSTRtree_create(size_t nodeCapacity);
+
+/*
+ * Insert an item into an STRtree
+ *
+ * @param tree the STRtree in which the item should be inserted
+ * @param g a GEOSGeometry whose envelope corresponds to the extent of 'item'
+ * @param item the item to insert into the tree
+ */
 extern void GEOS_DLL GEOSSTRtree_insert(GEOSSTRtree *tree,
                                         const GEOSGeometry *g,
                                         void *item);
+
+/*
+ * Query an STRtree for items intersecting a specified envelope
+ *
+ * @param tree the STRtree to search
+ * @param g a GEOSGeomety from which a query envelope will be extracted
+ * @param callback a function to be executed for each item in the tree whose envelope intersects
+ *            the envelope of 'g'.  The callback function should take two parameters: a void
+ *            pointer representing the located item in the tree, and a void userdata pointer.
+ * @param userdata an optional pointer to pe passed to 'callback' as an argument
+ */
 extern void GEOS_DLL GEOSSTRtree_query(GEOSSTRtree *tree,
                                        const GEOSGeometry *g,
                                        GEOSQueryCallback callback,
                                        void *userdata);
-extern const void* GEOS_DLL GEOSSTRtree_nearest(GEOSSTRtree *tree,
-                                        const GEOSGeometry* g,
-                                        int (*distancefn)(const void* item1, const void* item2, double* distance));
+/*
+ * Returns the nearest item in the STRtree to the supplied GEOSGeometry
+ *
+ * @param tree the STRtree to search
+ * @param geom the geometry with which the tree should be queried
+ * @return a const pointer to the nearest GEOSGeometry in the tree to 'geom', or NULL in
+ *            case of exception
+ */
+extern const GEOSGeometry* GEOS_DLL GEOSSTRtree_nearest(GEOSSTRtree *tree, const GEOSGeometry* geom);
+
+/*
+ * Returns the nearest item in the STRtree to the supplied item
+ *
+ * @param tree the STRtree to search
+ * @param item the item with which the tree should be queried
+ * @param itemEnvelope a GEOSGeometry having the bounding box of 'item'
+ * @param distancefn a function that can compute the distance between two items
+ *            in the STRtree.  The function should return zero in case of error,
+ *            and should store the computed distance to the location pointed to by
+ *            the 'distance' argument.  The computed distance between two items
+ *            must not exceed the Cartesian distance between their envelopes.
+ * @param userdata optional pointer to arbitrary data; will be passed to distancefn
+ *            each time it is called.
+ * @return a const pointer to the nearest item in the tree to 'item', or NULL in
+ *            case of exception
+ */
+extern const void* GEOS_DLL GEOSSTRtree_nearest_generic(GEOSSTRtree *tree,
+                                                        const void* item,
+                                                        const GEOSGeometry* itemEnvelope,
+                                                        int (*distancefn)(const void* item1, const void* item2, double* distance, void* userdata),
+                                                        void* userdata);
+/*
+ * Iterates over all items in the STRtree
+ *
+ * @param tree the STRtree over which to iterate
+ * @param callback a function to be executed for each item in the tree.
+ */
 extern void GEOS_DLL GEOSSTRtree_iterate(GEOSSTRtree *tree,
                                        GEOSQueryCallback callback,
                                        void *userdata);
+
+/*
+ * Removes an item from the STRtree
+ *
+ * @param tree the STRtree from which to remove an item
+ * @param g the envelope of the item to remove
+ * @param the item to remove
+ * @return 0 if the item was not removed;
+ *         1 if the item was removed;
+ *         2 if an exception occurred
+ */
 extern char GEOS_DLL GEOSSTRtree_remove(GEOSSTRtree *tree,
                                         const GEOSGeometry *g,
                                         void *item);

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -814,6 +814,10 @@ extern void GEOS_DLL GEOSSTRtree_query_r(GEOSContextHandle_t handle,
                                          const GEOSGeometry *g,
                                          GEOSQueryCallback callback,
                                          void *userdata);
+extern const void* GEOS_DLL GEOSSTRtree_nearest_r(GEOSContextHandle_t handle,
+                                                          GEOSSTRtree *tree,
+                                                          const GEOSGeometry* g,
+                                                          int (*distancefn)(const void* item1, const void* item2, double* distance));
 extern void GEOS_DLL GEOSSTRtree_iterate_r(GEOSContextHandle_t handle,
                                        GEOSSTRtree *tree,
                                        GEOSQueryCallback callback,
@@ -1659,6 +1663,9 @@ extern void GEOS_DLL GEOSSTRtree_query(GEOSSTRtree *tree,
                                        const GEOSGeometry *g,
                                        GEOSQueryCallback callback,
                                        void *userdata);
+extern const void* GEOS_DLL GEOSSTRtree_nearest(GEOSSTRtree *tree,
+                                        const GEOSGeometry* g,
+                                        int (*distancefn)(const void* item1, const void* item2, double* distance));
 extern void GEOS_DLL GEOSSTRtree_iterate(GEOSSTRtree *tree,
                                        GEOSQueryCallback callback,
                                        void *userdata);

--- a/capi/geos_c.h.in
+++ b/capi/geos_c.h.in
@@ -153,6 +153,7 @@ enum GEOSByteOrders {
 };
 
 typedef void (*GEOSQueryCallback)(void *item, void *userdata);
+typedef int (*GEOSDistanceCallback)(const void *item1, const void* item2, double* distance, void* userdata);
 
 /************************************************************************
  *
@@ -824,7 +825,7 @@ extern const void* GEOS_DLL GEOSSTRtree_nearest_generic_r(GEOSContextHandle_t ha
                                                           GEOSSTRtree *tree,
                                                           const void* item,
                                                           const GEOSGeometry* itemEnvelope,
-                                                          int (*distancefn)(const void* item1, const void* item2, double* distance, void* userdata),
+                                                          GEOSDistanceCallback distancefn,
                                                           void* userdata);
 
 extern void GEOS_DLL GEOSSTRtree_iterate_r(GEOSContextHandle_t handle,
@@ -1700,8 +1701,10 @@ extern void GEOS_DLL GEOSSTRtree_query(GEOSSTRtree *tree,
                                        GEOSQueryCallback callback,
                                        void *userdata);
 /*
- * Returns the nearest item in the STRtree to the supplied GEOSGeometry
- *
+ * Returns the nearest item in the STRtree to the supplied GEOSGeometry.
+ * All items in the tree MUST be of type GEOSGeometry.  If this is not the case, use
+ * GEOSSTRtree_nearest_generic instead.
+*
  * @param tree the STRtree to search
  * @param geom the geometry with which the tree should be queried
  * @return a const pointer to the nearest GEOSGeometry in the tree to 'geom', or NULL in
@@ -1728,7 +1731,7 @@ extern const GEOSGeometry* GEOS_DLL GEOSSTRtree_nearest(GEOSSTRtree *tree, const
 extern const void* GEOS_DLL GEOSSTRtree_nearest_generic(GEOSSTRtree *tree,
                                                         const void* item,
                                                         const GEOSGeometry* itemEnvelope,
-                                                        int (*distancefn)(const void* item1, const void* item2, double* distance, void* userdata),
+                                                        GEOSDistanceCallback distancefn,
                                                         void* userdata);
 /*
  * Iterates over all items in the STRtree

--- a/capi/geos_ts_c.cpp
+++ b/capi/geos_ts_c.cpp
@@ -5951,7 +5951,7 @@ GEOSSTRtree_nearest_generic_r(GEOSContextHandle_t extHandle,
                               geos::index::strtree::STRtree *tree,
                               const void* item,
                               const geos::geom::Geometry* itemEnvelope,
-                              int (*distancefn)(const void* item1, const void* item2, double* distance, void* userdata),
+                              GEOSDistanceCallback distancefn,
                               void* userdata)
 {
 
@@ -5960,10 +5960,10 @@ GEOSSTRtree_nearest_generic_r(GEOSContextHandle_t extHandle,
     {
         if (distancefn) {
             struct CustomItemDistance : public ItemDistance {
-                CustomItemDistance(int (*p_distancefn)(const void* item1, const void* item2, double* distance, void* p_userdata), void* p_userdata)
+                CustomItemDistance(GEOSDistanceCallback p_distancefn, void* p_userdata)
                         : m_distancefn(p_distancefn), m_userdata(p_userdata) {}
 
-                int (*m_distancefn)(const void* item1, const void* item2, double* distance, void* userdata);
+                GEOSDistanceCallback m_distancefn;
                 void* m_userdata;
 
                 double distance(const ItemBoundable* item1, const ItemBoundable* item2) {

--- a/include/geos/index/strtree/BoundablePair.h
+++ b/include/geos/index/strtree/BoundablePair.h
@@ -1,0 +1,114 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2016 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: index/strtree/BoundablePair.java (JTS-1.14)
+ *
+ **********************************************************************/
+
+#ifndef GEOS_INDEX_STRTREE_BOUNDABLEPAIR_H
+#define GEOS_INDEX_STRTREE_BOUNDABLEPAIR_H
+
+#include <geos/index/strtree/Boundable.h>
+#include <geos/index/strtree/ItemDistance.h>
+#include <queue>
+
+/**
+ * A pair of {@link Boundable}s, whose leaf items
+ * support a distance metric between them.
+ * Used to compute the distance between the members,
+ * and to expand a member relative to the other
+ * in order to produce new branches of the
+ * Branch-and-Bound evaluation tree.
+ * Provides an ordering based on the distance between the members,
+ * which allows building a priority queue by minimum distance.
+ *
+ * @author Martin Davis
+ *
+ */
+
+using namespace geos::index::strtree;
+
+
+namespace geos {
+namespace index {
+namespace strtree {
+class BoundablePair {
+	private:
+		const Boundable* boundable1;
+		const Boundable* boundable2;
+		ItemDistance* itemDistance;
+		double mDistance;
+
+	public:
+		struct BoundablePairQueueCompare {
+			bool operator()(const BoundablePair* a, const BoundablePair* b) {
+				return a->getDistance() > b->getDistance();
+			}
+		};
+
+		typedef std::priority_queue<BoundablePair*, std::vector<BoundablePair*>, BoundablePairQueueCompare> BoundablePairQueue;
+		BoundablePair(const Boundable* boundable1, const Boundable* boundable2, ItemDistance* itemDistance);
+
+		/**
+		 * Gets one of the member {@link Boundable}s in the pair
+		 * (indexed by [0, 1]).
+		 *
+		 * @param i the index of the member to return (0 or 1)
+		 * @return the chosen member
+		 */
+		const Boundable* getBoundable(int i) const;
+
+		/**
+		 * Computes the distance between the {@link Boundable}s in this pair.
+		 * The boundables are either composites or leaves.
+		 * If either is composite, the distance is computed as the minimum distance
+		 * between the bounds.
+		 * If both are leaves, the distance is computed by {@link #itemDistance(ItemBoundable, ItemBoundable)}.
+		 *
+		 * @return
+		 */
+		double distance();
+
+		/**
+		 * Gets the minimum possible distance between the Boundables in
+		 * this pair.
+		 * If the members are both items, this will be the
+		 * exact distance between them.
+		 * Otherwise, this distance will be a lower bound on
+		 * the distances between the items in the members.
+		 *
+		 * @return the exact or lower bound distance for this pair
+		 */
+		double getDistance() const;
+
+		/**
+		 * Tests if both elements of the pair are leaf nodes
+		 *
+		 * @return true if both pair elements are leaf nodes
+		 */
+		bool isLeaves() const;
+
+		static bool isComposite(const Boundable* item);
+
+		static double area(const Boundable* b);
+
+		void expandToQueue(BoundablePairQueue &, double minDistance);
+		void expand(const Boundable* bndComposite, const Boundable* bndOther, BoundablePairQueue & priQ, double minDistance);
+};
+}
+}
+}
+
+#endif
+

--- a/include/geos/index/strtree/GeometryItemDistance.h
+++ b/include/geos/index/strtree/GeometryItemDistance.h
@@ -1,0 +1,45 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2016 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: index/strtree/GeometryItemDistance.java (JTS-1.14)
+ *
+ **********************************************************************/
+
+#ifndef GEOS_INDEX_STRTREE_GEOMETRYITEMDISTANCE_H
+#define GEOS_INDEX_STRTREE_GEOMETRYITEMDISTANCE_H
+
+#include <geos/geom/Geometry.h>
+#include <geos/index/strtree/ItemDistance.h>
+
+namespace geos {
+namespace index {
+namespace strtree {
+class GeometryItemDistance : public ItemDistance {
+public:
+	/**
+	 * Computes the distance between two {@link Geometry} items,
+	 * using the {@link Geometry#distance(Geometry)} method.
+	 *
+	 * @param item1 an item which is a Geometry
+	 * @param item2 an item which is a Geometry
+	 * @return the distance between the geometries
+	 * @throws ClassCastException if either item is not a Geometry
+	 */
+	double distance(const ItemBoundable* item1, const ItemBoundable* item2);
+};
+}
+}
+}
+
+#endif //GEOS_GEOMETRYITEMDISTANCE_H

--- a/include/geos/index/strtree/ItemDistance.h
+++ b/include/geos/index/strtree/ItemDistance.h
@@ -1,0 +1,44 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2016 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: index/strtree/ItemDistance.java (JTS-1.14)
+ *
+ **********************************************************************/
+
+#ifndef GEOS_INDEX_STRTREE_ITEMDISTANCE_H
+#define GEOS_INDEX_STRTREE_ITEMDISTANCE_H
+
+#include <geos/index/strtree/ItemBoundable.h>
+
+namespace geos {
+namespace index {
+namespace strtree {
+class GEOS_DLL ItemDistance {
+public:
+	/**
+	 * Computes the distance between two items.
+	 *
+	 * @param item1
+	 * @param item2
+	 * @return the distance between the items
+	 *
+	 * @throws IllegalArgumentException if the metric is not applicable to the arguments
+	 */
+	virtual double distance(const ItemBoundable* item1, const ItemBoundable* item2) = 0;
+};
+}
+}
+}
+
+#endif //GEOS_ITEMDISTANCE_H

--- a/include/geos/index/strtree/STRtree.h
+++ b/include/geos/index/strtree/STRtree.h
@@ -20,6 +20,8 @@
 #define GEOS_INDEX_STRTREE_STRTREE_H
 
 #include <geos/export.h>
+#include <geos/index/strtree/ItemDistance.h>
+#include <geos/index/strtree/BoundablePair.h>
 #include <geos/index/strtree/AbstractSTRtree.h> // for inheritance
 #include <geos/index/SpatialIndex.h> // for inheritance
 #include <geos/geom/Envelope.h> // for inlines
@@ -136,6 +138,10 @@ public:
 	void query(const geom::Envelope *searchEnv, ItemVisitor& visitor) {
 		return AbstractSTRtree::query(searchEnv, visitor);
 	}
+
+	const void* nearestNeighbour(const geom::Envelope *env, const void* item, ItemDistance* itemDist);
+	const void* nearestNeighbour(BoundablePair* initBndPair);
+	const void* nearestNeighbour(BoundablePair* initBndPair, double maxDistance);
 
 	bool remove(const geom::Envelope *itemEnv, void* item) {
 		return AbstractSTRtree::remove(itemEnv, item);

--- a/src/index/strtree/AbstractSTRtree.cpp
+++ b/src/index/strtree/AbstractSTRtree.cpp
@@ -55,7 +55,9 @@ AbstractSTRtree::~AbstractSTRtree()
 void
 AbstractSTRtree::build()
 {
-	assert(!built);
+	if(built)
+		return;
+
 	root=(itemBoundables->empty()?createNode(0):createHigherLevels(itemBoundables,-1));
 	built=true;
 }

--- a/src/index/strtree/BoundablePair.cpp
+++ b/src/index/strtree/BoundablePair.cpp
@@ -1,0 +1,107 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2016 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: index/strtree/BoundablePair.java (JTS-1.14)
+ *
+ **********************************************************************/
+
+#include <geos/index/strtree/BoundablePair.h>
+#include <geos/geom/Envelope.h>
+#include <geos/index/strtree/AbstractNode.h>
+#include <geos/util/IllegalArgumentException.h>
+
+BoundablePair::BoundablePair(const Boundable* boundable1, const Boundable* boundable2, ItemDistance* itemDistance) :
+	boundable1(boundable1),
+	boundable2(boundable2),
+	itemDistance(itemDistance)
+{
+	mDistance = distance();
+}
+
+const Boundable* BoundablePair::getBoundable(int i) const {
+	if (i == 0)
+		return boundable1;
+	return boundable2;
+}
+
+double BoundablePair::distance() {
+	// if items, compute exact distance
+	if (isLeaves())
+		return itemDistance->distance((ItemBoundable*) boundable1, (ItemBoundable*) boundable2);
+
+	// otherwise compute distance between bounds of boundables
+	const geom::Envelope* e1 = (const geom::Envelope*) boundable1->getBounds();
+	const geom::Envelope* e2 = (const geom::Envelope*) boundable2->getBounds();
+	return e1->distance(e2);
+}
+
+double BoundablePair::getDistance() const {
+	return mDistance;
+}
+
+bool BoundablePair::isLeaves() const {
+	return !(isComposite(boundable1) || isComposite(boundable2));
+}
+
+bool BoundablePair::isComposite(const Boundable* item) {
+	return dynamic_cast<const AbstractNode*>(item) != NULL;
+}
+
+double BoundablePair::area(const Boundable* b) {
+	return ((const geos::geom::Envelope*) b->getBounds())->getArea();
+}
+
+void BoundablePair::expandToQueue(BoundablePairQueue & priQ, double minDistance) {
+	bool isComp1 = isComposite(boundable1);
+	bool isComp2 = isComposite(boundable2);
+
+	/**
+	 * HEURISTIC: If both boundables are composite,
+	 * choose the one with largest area to expand.
+	 * Otherwise, simply expand whichever is composite.
+	 */
+	if (isComp1 && isComp2) {
+		if (area(boundable1) > area(boundable2)) {
+			expand(boundable1, boundable2, priQ, minDistance);
+			return;
+		} else {
+			expand(boundable2, boundable1, priQ, minDistance);
+			return;
+		}
+	}
+	else if (isComp1) {
+		expand(boundable1, boundable2, priQ, minDistance);
+		return;
+	}
+	else if (isComp2) {
+		expand(boundable2, boundable1, priQ, minDistance);
+		return;
+	}
+
+	throw new geos::util::IllegalArgumentException("neither boundable is composite");
+}
+
+void BoundablePair::expand(const Boundable* bndComposite, const Boundable* bndOther, BoundablePairQueue & priQ, double minDistance) {
+	std::vector<Boundable*> *children = ((AbstractNode*) bndComposite)->getChildBoundables();
+	for(std::vector<Boundable*>::iterator it = children->begin(); it != children->end(); ++it) {
+		Boundable* child = *it;
+		BoundablePair* bp = new BoundablePair(child, bndOther, itemDistance);
+		if (bp->getDistance() < minDistance) {
+			priQ.push(bp);
+		} else {
+			delete bp;
+		}
+	}
+}
+

--- a/src/index/strtree/BoundablePair.cpp
+++ b/src/index/strtree/BoundablePair.cpp
@@ -43,6 +43,9 @@ double BoundablePair::distance() {
 	// otherwise compute distance between bounds of boundables
 	const geom::Envelope* e1 = (const geom::Envelope*) boundable1->getBounds();
 	const geom::Envelope* e2 = (const geom::Envelope*) boundable2->getBounds();
+
+	if (!e1 || !e2)
+		throw util::GEOSException("Can't compute envelope of item in BoundablePair");
 	return e1->distance(e2);
 }
 

--- a/src/index/strtree/GeometryItemDistance.cpp
+++ b/src/index/strtree/GeometryItemDistance.cpp
@@ -1,0 +1,30 @@
+/**********************************************************************
+ *
+ * GEOS - Geometry Engine Open Source
+ * http://geos.osgeo.org
+ *
+ * Copyright (C) 2016 Daniel Baston
+ *
+ * This is free software; you can redistribute and/or modify it under
+ * the terms of the GNU Lesser General Public Licence as published
+ * by the Free Software Foundation.
+ * See the COPYING file for more information.
+ *
+ **********************************************************************
+ *
+ * Last port: index/strtree/GeometryItemDistance.java (JTS-1.14)
+ *
+ **********************************************************************/
+
+#include <geos/geom/Geometry.h>
+#include <geos/index/strtree/ItemBoundable.h>
+#include <geos/index/strtree/GeometryItemDistance.h>
+
+using namespace geos::geom;
+using namespace geos::index::strtree;
+
+double GeometryItemDistance::distance(const ItemBoundable* item1, const ItemBoundable* item2) {
+	const Geometry* g1 = (Geometry*) item1->getItem();
+	const Geometry* g2 = (Geometry*) item2->getItem();
+	return g1->distance(g2);
+}

--- a/src/index/strtree/Makefile.am
+++ b/src/index/strtree/Makefile.am
@@ -8,9 +8,11 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 libindexstrtree_la_SOURCES = \
     AbstractNode.cpp \
     AbstractSTRtree.cpp \
+    BoundablePair.cpp \
+    GeometryItemDistance.cpp \
     Interval.cpp \
     ItemBoundable.cpp \
     SIRtree.cpp \
-    STRtree.cpp 
+    STRtree.cpp
 
 libindexstrtree_la_LIBADD = 

--- a/src/index/strtree/STRtree.cpp
+++ b/src/index/strtree/STRtree.cpp
@@ -18,6 +18,7 @@
  **********************************************************************/
 
 #include <geos/index/strtree/STRtree.h>
+#include <geos/index/strtree/BoundablePair.h>
 #include <geos/geom/Envelope.h>
 
 #include <vector>
@@ -181,6 +182,80 @@ STRtree::verticalSlices(BoundableList* childBoundables, size_t sliceCount)
 		}
 	}
 	return slices;
+}
+
+/*public*/
+const void* STRtree::nearestNeighbour(const Envelope* env, const void* item, ItemDistance* itemDist) {
+	build();
+
+	ItemBoundable bnd = ItemBoundable(env, (void*) item);
+	BoundablePair bp(getRoot(), &bnd, itemDist);
+
+	return nearestNeighbour(&bp);
+}
+
+const void* STRtree::nearestNeighbour(BoundablePair* initBndPair) {
+	return nearestNeighbour(initBndPair, DoubleInfinity);
+}
+
+const void* STRtree::nearestNeighbour(BoundablePair* initBndPair, double maxDistance) {
+	double distanceLowerBound = maxDistance;
+	BoundablePair* minPair = NULL;
+
+	BoundablePair::BoundablePairQueue priQ;
+	priQ.push(initBndPair);
+
+	while(!priQ.empty() && distanceLowerBound > 0.0) {
+		BoundablePair* bndPair = priQ.top();
+		double currentDistance = bndPair->getDistance();
+
+		/**
+		 * If the distance for the first node in the queue
+		 * is >= the current minimum distance, all other nodes
+		 * in the queue must also have a greater distance.
+		 * So the current minDistance must be the true minimum,
+		 * and we are done.
+		 */
+		if (currentDistance >= distanceLowerBound)
+			break;
+
+		priQ.pop();
+
+		/**
+		 * If the pair members are leaves
+		 * then their distance is the exact lower bound.
+		 * Update the distanceLowerBound to reflect this
+		 * (which must be smaller, due to the test
+		 * immediately prior to this).
+		 */
+		if (bndPair->isLeaves()) {
+			distanceLowerBound = currentDistance;
+			minPair = bndPair;
+		} else {
+			/**
+			 * Otherwise, expand one side of the pair,
+			 * (the choice of which side to expand is heuristically determined)
+			 * and insert the new expanded pairs into the queue
+			 */
+			bndPair->expandToQueue(priQ, distanceLowerBound);
+		}
+
+		if (bndPair != initBndPair && bndPair != minPair)
+            delete bndPair;
+	}
+
+	/* Free any remaining BoundablePairs in the queue */
+	while(!priQ.empty()) {
+		BoundablePair* bp = priQ.top();
+		priQ.pop();
+		delete bp;
+	}
+
+	const void* retval = dynamic_cast<const ItemBoundable*>(minPair->getBoundable(0))->getItem();
+	if (minPair != initBndPair)
+        delete minPair;
+
+	return retval;
 }
 
 class STRAbstractNode: public AbstractNode{

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -149,6 +149,7 @@ geos_unit_SOURCES = \
 	capi/GEOSNodeTest.cpp \
 	capi/GEOSSnapTest.cpp \
 	capi/GEOSSharedPathsTest.cpp \
+	capi/GEOSSTRtreeTest.cpp \
 	capi/GEOSRelateBoundaryNodeRuleTest.cpp \
 	capi/GEOSRelatePatternMatchTest.cpp \
 	capi/GEOSUnaryUnionTest.cpp \

--- a/tests/unit/capi/GEOSSTRtreeTest.cpp
+++ b/tests/unit/capi/GEOSSTRtreeTest.cpp
@@ -188,6 +188,48 @@ namespace tut
 		GEOSSTRtree_destroy(tree);
 	}
 
+	// GEOSSTRtree_nearest with a tree of empty geometries
+	template<>
+	template<>
+	void object::test<5>() {
+		GEOSGeometry* g1 = GEOSGeomFromWKT("LINESTRING EMPTY");
+		GEOSGeometry* g2 = GEOSGeomFromWKT("POINT (2 7)");
+
+		GEOSSTRtree* tree = GEOSSTRtree_create(4);
+		GEOSSTRtree_insert(tree, g1, g1);
+
+		const GEOSGeometry* g3 = GEOSSTRtree_nearest(tree, g2);
+		ensure(g3 == NULL);
+
+		GEOSGeom_destroy(g1);
+		GEOSGeom_destroy(g2);
+		GEOSSTRtree_destroy(tree);
+	}
+
+	// GEOSSTRtree_nearest with a tree containing some empty geometries
+	template<>
+	template<>
+	void object::test<6>() {
+		GEOSGeometry* g1 = GEOSGeomFromWKT("LINESTRING EMPTY");
+		GEOSGeometry* g2 = GEOSGeomFromWKT("POINT (2 7)");
+		GEOSGeometry* g3 = GEOSGeomFromWKT("POINT (12 97)");
+		GEOSGeometry* g4 = GEOSGeomFromWKT("LINESTRING (3 8, 4 8)");
+
+		GEOSSTRtree* tree = GEOSSTRtree_create(4);
+		GEOSSTRtree_insert(tree, g1, g1);
+		GEOSSTRtree_insert(tree, g2, g2);
+		GEOSSTRtree_insert(tree, g3, g3);
+
+		const GEOSGeometry* g5 = (const GEOSGeometry*) GEOSSTRtree_nearest(tree, g4);
+		ensure(g5 == g2);
+
+		GEOSGeom_destroy(g1);
+		GEOSGeom_destroy(g2);
+		GEOSGeom_destroy(g3);
+		GEOSGeom_destroy(g4);
+		GEOSSTRtree_destroy(tree);
+	}
+
 } // namespace tut
 
 

--- a/tests/unit/capi/GEOSSTRtreeTest.cpp
+++ b/tests/unit/capi/GEOSSTRtreeTest.cpp
@@ -11,7 +11,7 @@
 #include <cmath>
 
 struct INTPOINT {
-	INTPOINT(int x, int y) : x{x}, y{y} {}
+	INTPOINT(int x, int y) : x(x), y(y) {}
 	int x;
 	int y;
 };
@@ -106,7 +106,7 @@ namespace tut
 		std::vector<GEOSGeometry*> queryPoints;
 		GEOSSTRtree* tree = GEOSSTRtree_create(ngeoms);
 
-		for (auto i = 0; i < ngeoms; i++) {
+		for (size_t i = 0; i < ngeoms; i++) {
 			GEOSCoordSequence* seq = GEOSCoordSeq_create(1, 2);
 			GEOSCoordSeq_setX(seq, 0, std::rand());
 			GEOSCoordSeq_setY(seq, 0, std::rand());
@@ -114,18 +114,18 @@ namespace tut
 			GEOSSTRtree_insert(tree, geoms[i], geoms[i]);
 		}
 
-		for (auto i = 0; i < ngeoms; i++) {
+		for (size_t i = 0; i < ngeoms; i++) {
 			GEOSCoordSequence* seq = GEOSCoordSeq_create(1, 2);
 			GEOSCoordSeq_setX(seq, 0, std::rand());
 			GEOSCoordSeq_setY(seq, 0, std::rand());
 			queryPoints.push_back(GEOSGeom_createPoint(seq));
 		}
 
-		for (auto i = 0; i < ngeoms; i++) {
+		for (size_t i = 0; i < ngeoms; i++) {
 			const GEOSGeometry* nearest = GEOSSTRtree_nearest(tree, queryPoints[i]);
 			const GEOSGeometry* nearestBruteForce = NULL;
 			double nearestBruteForceDistance = std::numeric_limits<double>::max();
-			for (auto j = 0; j < ngeoms; j++) {
+			for (size_t j = 0; j < ngeoms; j++) {
 				double distance;
 				GEOSDistance(queryPoints[i], geoms[j], &distance);
 
@@ -138,7 +138,7 @@ namespace tut
 			ensure(nearest == nearestBruteForce || GEOSEquals(nearest, nearestBruteForce));
 		}
 
-		for (int i = 0; i < ngeoms; i++) {
+		for (size_t i = 0; i < ngeoms; i++) {
 			GEOSGeom_destroy(geoms[i]);
 			GEOSGeom_destroy(queryPoints[i]);
 		}

--- a/tests/unit/capi/GEOSSTRtreeTest.cpp
+++ b/tests/unit/capi/GEOSSTRtreeTest.cpp
@@ -1,0 +1,128 @@
+//
+// Test Suite for C-API GEOSSTRtree
+
+#include <tut.hpp>
+// geos
+#include <geos_c.h>
+// std
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace tut
+{
+	//
+	// Test Group
+	//
+
+	// Common data used in test cases.
+	struct test_capistrtree_data
+	{
+		test_capistrtree_data() {
+			initGEOS(notice, notice);
+		}
+
+		static void notice(const char *fmt, ...)
+		{
+			std::fprintf( stdout, "NOTICE: ");
+
+			va_list ap;
+			va_start(ap, fmt);
+			std::vfprintf(stdout, fmt, ap);
+			va_end(ap);
+
+			std::fprintf(stdout, "\n");
+		}
+
+	};
+
+	typedef test_group<test_capistrtree_data> group;
+	typedef group::object object;
+
+	group test_capistrtree_group("capi::GEOSSTRtree");
+
+	//
+	// Test Cases
+	//
+
+	// Test GEOSSTRtree_nearest with a couple of points
+	template<>
+	template<>
+	void object::test<1>()
+	{
+		GEOSGeometry* g1 = GEOSGeomFromWKT("POINT (3 3)");
+		GEOSGeometry* g2 = GEOSGeomFromWKT("POINT (2 7)");
+		GEOSGeometry* g3 = GEOSGeomFromWKT("POINT (5 4)");
+		GEOSGeometry* g4 = GEOSGeomFromWKT("POINT (3 8)");
+
+		GEOSSTRtree* tree = GEOSSTRtree_create(2);
+		GEOSSTRtree_insert(tree, g1, g1);
+		GEOSSTRtree_insert(tree, g2, g2);
+		GEOSSTRtree_insert(tree, g3, g3);
+
+		const GEOSGeometry* g5 = (GEOSGeometry*) GEOSSTRtree_nearest(tree, g4,
+		(int (*)(const void* item1, const void* item2, double* distance))(GEOSDistance));
+		ensure(g5 == g2);
+
+		GEOSGeom_destroy(g1);
+		GEOSGeom_destroy(g2);
+		GEOSGeom_destroy(g3);
+		GEOSGeom_destroy(g4);
+		GEOSSTRtree_destroy(tree);
+	}
+
+	// Test GEOSSTRtree_nearest with more points.  This is important because we need to make sure the tree
+	// actually has a couple of layers of depth.
+	template<>
+	template<>
+	void object::test<2>()
+	{
+		int ngeoms = 100;
+		std::vector<GEOSGeometry*> geoms;
+		std::vector<GEOSGeometry*> queryPoints;
+		GEOSSTRtree* tree = GEOSSTRtree_create(ngeoms);
+
+		for (int i = 0; i < ngeoms; i++) {
+			GEOSCoordSequence* seq = GEOSCoordSeq_create(1, 2);
+			GEOSCoordSeq_setX(seq, 0, std::rand());
+			GEOSCoordSeq_setY(seq, 0, std::rand());
+			geoms.push_back(GEOSGeom_createPoint(seq));
+			GEOSSTRtree_insert(tree, geoms[i], geoms[i]);
+		}
+
+		for (int i = 0; i < ngeoms; i++) {
+			GEOSCoordSequence* seq = GEOSCoordSeq_create(1, 2);
+			GEOSCoordSeq_setX(seq, 0, std::rand());
+			GEOSCoordSeq_setY(seq, 0, std::rand());
+			queryPoints.push_back(GEOSGeom_createPoint(seq));
+		}
+
+		for (int i = 0; i < ngeoms; i++) {
+			const GEOSGeometry* nearest = (GEOSGeometry*) GEOSSTRtree_nearest(tree, queryPoints[i], NULL);
+			const GEOSGeometry* nearestBruteForce = NULL;
+			double nearestBruteForceDistance;
+			for (int j = 0; j < ngeoms; j++) {
+				double distance;
+				GEOSDistance(queryPoints[i], geoms[j], &distance);
+
+				if (nearestBruteForce == NULL || distance < nearestBruteForceDistance) {
+					nearestBruteForce = geoms[j];
+					nearestBruteForceDistance = distance;
+				}
+			}
+
+			ensure(nearest == nearestBruteForce || GEOSEquals(nearest, nearestBruteForce));
+		}
+
+		for (int i = 0; i < ngeoms; i++) {
+			GEOSGeom_destroy(geoms[i]);
+			GEOSGeom_destroy(queryPoints[i]);
+		}
+
+		GEOSSTRtree_destroy(tree);
+	}
+
+
+} // namespace tut
+


### PR DESCRIPTION
https://trac.osgeo.org/geos/ticket/768

This is a necessary precursor to implementing MinimumClearance in GEOS/PostGIS, but useful in its own right.