### PR TITLE
Match .h declaration parameter name with .cpp definitiion.

### DIFF
--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -356,7 +356,7 @@ public:
 	 * @return true if an intersection was found, false otherwise
 	 *
 	 */
-	bool lineIntersection(const LineSegment& line, Coordinate& coord) const;
+	bool lineIntersection(const LineSegment& line, Coordinate& ret) const;
 
 	/**
 	 * Creates a LineString with the same coordinates as this segment

--- a/include/geos/geom/LineSegment.h
+++ b/include/geos/geom/LineSegment.h
@@ -61,7 +61,7 @@ public:
 
 	Coordinate p0; /// Segment start
 
-	Coordinate p1; /// Segemnt end
+	Coordinate p1; /// Segment end
 
 	LineSegment();
 


### PR DESCRIPTION
The Doxygen docs are a little confusing here because the parameter name doesn't match. This minor touch-up clears things up a little.