### PR TITLE
CMake: allow only build shared/static with cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,12 @@ if(NOT MSVC)
     "Set to ON|OFF (default) to build GEOS with assert() macro enabled" OFF)
 endif()
 
+option(GEOS_BUILD_STATIC
+  "Set to OFF|ON (default) to build GEOS static libraries" ON)
+
+option(GEOS_BUILD_SHARED
+  "Set to OFF|ON (default) to build GEOS shared libraries" ON)
+
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
   option(GEOS_ENABLE_FLOATSTORE
     "Set to OFF|ON (default) to control IEEE754 conformance and remove extra precision" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,22 +61,38 @@ if(GEOS_ENABLE_MACOSX_FRAMEWORK)
 
 else()
 
-  add_library(geos SHARED ${geos_SOURCES} ${geos_ALL_HEADERS})
-  add_library(geos-static STATIC ${geos_SOURCES} ${geos_ALL_HEADERS})
+  if(GEOS_BUILD_SHARED)
+    add_library(geos SHARED ${geos_SOURCES} ${geos_ALL_HEADERS})
 
-  set_target_properties(geos
-    PROPERTIES
-    DEFINE_SYMBOL GEOS_DLL_EXPORT
-    VERSION ${VERSION}
-    CLEAN_DIRECT_OUTPUT 1)
+    set_target_properties(geos
+      PROPERTIES
+      DEFINE_SYMBOL GEOS_DLL_EXPORT
+      VERSION ${VERSION}
+      CLEAN_DIRECT_OUTPUT 1)
 
-  set_target_properties(geos-static
-    PROPERTIES
-    OUTPUT_NAME "geos"
-    PREFIX "lib"
-    CLEAN_DIRECT_OUTPUT 1)
+    install(TARGETS geos
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib)
+  endif()
 
-endif()
+  if(GEOS_BUILD_STATIC)
+    add_library(geos-static STATIC ${geos_SOURCES} ${geos_ALL_HEADERS})
+
+    set_target_properties(geos-static
+      PROPERTIES
+      OUTPUT_NAME "geos"
+      PREFIX "lib"
+      CLEAN_DIRECT_OUTPUT 1)
+
+    install(TARGETS geos-static
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib)
+
+  endif()
+
+endif() # (GEOS_ENABLE_MACOSX_FRAMEWORK)
 
 # if(APPLE)
 #   set_target_properties(geos
@@ -85,16 +101,6 @@ endif()
 #     INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}")
 # endif()
 
-#################################################################################
-# Installation
-#################################################################################
-
-if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK)
-  install(TARGETS geos geos-static
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
-endif()
 
 #################################################################################
 # Group source files for IDE source explorers (e.g. Visual Studio)


### PR DESCRIPTION
the default is now build both static and shared. This is kept unchaned.
if GEOS_BUILD_SHARED or GEOS_BUILD_STATIC is OFF, then only that build is done.

GEOS_BUILD_PACKAGED option is removed and instead a check for geos_svn_revision.h is used.