### PR TITLE
IndexedFacetDistance

### DIFF
--- a/include/geos/operation/distance/IndexedFacetDistance.h
+++ b/include/geos/operation/distance/IndexedFacetDistance.h
@@ -34,6 +34,8 @@ namespace geos {
 
                 double getDistance(const geom::Geometry * g) const;
 
+                ~IndexedFacetDistance();
+
             private:
                 std::auto_ptr<geos::index::strtree::STRtree> cachedTree;
 


### PR DESCRIPTION
This PR ports the IndexedFacetDistance class from JTS, which can massively speed up distance calculations.  It adds a `GEOSDistanceIndexed` method to the C API which can take advantage of this.  There is currently no way in the C API to reuse an `IndexedFacetDistance` for multiple calculations, although this could be added in the future.
