### PR TITLE
Update geos-config.in

### DIFF
--- a/tools/geos-config.in
+++ b/tools/geos-config.in
@@ -52,10 +52,10 @@ case $1 in
       echo -L${libdir} -lgeos
       ;;
     --static-clibs)
-      echo -L${libdir} -lgeos_c -lgeos -m
+      echo -L${libdir} -lgeos_c -lgeos -lm
       ;;
     --static-cclibs)
-      echo -L${libdir} -lgeos -m
+      echo -L${libdir} -lgeos -lm
       ;;
     --ldflags)
       echo -L${libdir}


### PR DESCRIPTION
-m breaks clang compilation; https://trac.osgeo.org/geos/ticket/497 also mentions -lm, not -m