### PR TITLE
fixes for MSVC compilation

### DIFF
--- a/include/geos/operation/distance/FacetSequenceTreeBuilder.h
+++ b/include/geos/operation/distance/FacetSequenceTreeBuilder.h
@@ -27,7 +27,7 @@
 namespace geos {
     namespace operation {
         namespace distance {
-            class FacetSequenceTreeBuilder {
+            class GEOS_DLL FacetSequenceTreeBuilder {
             private:
                 // 6 seems to be a good facet sequence size
                 static const int FACET_SEQUENCE_SIZE = 6;

--- a/tests/unit/capi/GEOSDistanceTest.cpp
+++ b/tests/unit/capi/GEOSDistanceTest.cpp
@@ -10,6 +10,9 @@
 #include <cstdlib>
 #include <memory>
 #include <math.h>
+#ifndef M_PI
+#define M_PI       3.14159265358979323846
+#endif
 
 namespace tut
 {


### PR DESCRIPTION
missing GEOS_DLL and USE_MATH_DEFINES (M_PI is not standard C++)